### PR TITLE
Fix search input

### DIFF
--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -75,8 +75,8 @@ const StyledInput = styled.input<InputProps>`
     cursor: not-allowed;
   }
 
-  ${({ search }) =>
-    search &&
+  ${({ type }) =>
+    type === "search" &&
     css`
       margin-left: 0.5rem;
     `}
@@ -95,12 +95,9 @@ export const Description = (props: any) => (
 
 export const Input: React.FC<InputProps> = props => (
   <InputGroup>
-    {props.search && <Icon image={"SEARCH"} width="24px" height="24px" />}
-    <StyledInput
-      as="input"
-      type={props.type || "text"}
-      id={props.name}
-      {...props}
-    />
+    {props.type === "search" && (
+      <Icon image="SEARCH" width="1.2rem" height="1.2rem" />
+    )}
+    <StyledInput type={props.type || "text"} id={props.name} {...props} />
   </InputGroup>
 );

--- a/src/stories/3-Input.stories.js
+++ b/src/stories/3-Input.stories.js
@@ -40,10 +40,9 @@ stories
     return (
       <Input
         name={text("Name", "Input name")}
-        type={select("Type", inputTypes, "text")}
+        type={select("Type", inputTypes, "search")}
         placeholder={text("Placeholder", "Placeholder")}
         disabled={boolean("Disabled", false)}
-        search
       />
     );
   })


### PR DESCRIPTION
`<Input>` should display search icon when `type` is set to `search`.  Icon shouldn't be higher than `<Input>` to avoid inputs scaling.