### PR TITLE
Add line height property to Text

### DIFF
--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -23,7 +23,6 @@ const basicStyles = css<TextProps>`
   line-height: ${theme.lineHeight};
   font-weight: ${theme.fontWeights.regular};
   font-size: ${theme.fontSizes.regular};
-  line-height: ${theme.typography.lineHeight};
   color: ${(props) => props.color || theme.colors.primary};
 `;
 


### PR DESCRIPTION
Previously `line-height` was attached to `Container` component which provides some bugs (i.e.  `Heading`) . It was checked if the removing this part of code will affect other components with good result—but please be aware and check this one more time while reviewing this PR just to be sure.