### PR TITLE
Improve Storybooks design

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,13 +1,20 @@
 import React from "react";
 import { addDecorator } from "@storybook/react";
+import { addParameters } from "@storybook/react";
 import { withInfo } from "@storybook/addon-info";
 import "./global.css";
 
 addDecorator(
   withInfo({
     header: true,
-    styles: {}
+    styles: {},
   })
 );
 
-addDecorator(storyFn => <>{storyFn()}</>);
+addParameters({
+  options: {
+    showRoots: true,
+  },
+});
+
+addDecorator((storyFn) => <>{storyFn()}</>);


### PR DESCRIPTION
Storybook offers better looking design for table of contents on the left sidebar so I think we should take it.

**Previously**:
<img width="212" alt="Zrzut ekranu 2020-04-30 o 12 14 00" src="https://user-images.githubusercontent.com/35585466/80699337-15b76480-8adc-11ea-861b-a78a539ee6cb.png">

**Next**:
<img width="206" alt="Zrzut ekranu 2020-04-30 o 11 49 09" src="https://user-images.githubusercontent.com/35585466/80697128-d20f2b80-8ad8-11ea-967c-259fa1d5a2f0.png">
