### PR TITLE
Removed Extra Items from Accordion Header

### DIFF
--- a/src/stories/Accordion.stories.mdx
+++ b/src/stories/Accordion.stories.mdx
@@ -31,17 +31,11 @@ import { Accordion, AccordionHeader, AccordionItem } from "../components/accordi
     <Accordion>
         <AccordionHeader title="Header 1" description="description...">
             <AccordionItem>1234</AccordionItem>
-            <AccordionItem>1234</AccordionItem>
-            <AccordionItem>1234</AccordionItem>
         </AccordionHeader>
         <AccordionHeader title="Header 2" description="description...">
             <AccordionItem>1234</AccordionItem>
-            <AccordionItem>1234</AccordionItem>
-            <AccordionItem>1234</AccordionItem>
         </AccordionHeader>
         <AccordionHeader title="Header 3" description="description...">
-            <AccordionItem>1234</AccordionItem>
-            <AccordionItem>1234</AccordionItem>
             <AccordionItem>1234</AccordionItem>
         </AccordionHeader>
     </Accordion>


### PR DESCRIPTION
## Description 
Removed the extra Items from the Accordion Header

## Issue No. #185 

## Issue : 
Multiple Items in Accordion

<img width="990" alt="95425823-2bf80500-0945-11eb-9efb-d14bab83638d" src="https://user-images.githubusercontent.com/32139101/95563807-85daf680-0a3b-11eb-86e7-863d8f5fedc0.png">

## Fix :

Only one Element in the Accordion
![fi](https://user-images.githubusercontent.com/32139101/95564095-eec26e80-0a3b-11eb-9cef-544e5fef73ab.png)

