### PR TITLE
[Issue 210] Reorganize Stories

### DIFF
--- a/src/components/accordion/Accordion.stories.mdx
+++ b/src/components/accordion/Accordion.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Accordion, AccordionHeader, AccordionItem } from "../components/accordion";
+import { Accordion, AccordionHeader, AccordionItem } from "./";
 
 <Meta title="Components/Accordion" component={Accordion} />
 

--- a/src/components/barchart/BarChart.stories.mdx
+++ b/src/components/barchart/BarChart.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { BarChart } from "../components/barchart";
-import theme from "../theme";
+import { BarChart } from "./";
+import theme from "../../theme";
 
 <Meta title="Components/BarChart" component={BarChart} />
 

--- a/src/components/box/Box.stories.mdx
+++ b/src/components/box/Box.stories.mdx
@@ -6,9 +6,9 @@ import {
   Description,
   Props,
 } from "@storybook/addon-docs/blocks";
-import { Box } from "../components/box";
-import { Spacer } from "../components/spacer";
-import { GnuiContainer } from "../components/container";
+import { Box } from ".";
+import { Spacer } from "../spacer";
+import { GnuiContainer } from "../container";
 
 <Meta title="Components/Box" component={Box} />
 

--- a/src/components/breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/components/breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Breadcrumbs } from "../components/breadcrumbs";
+import { Breadcrumbs } from ".";
 
 <Meta title="Components/Breadcrumbs" component={Breadcrumbs} />
 

--- a/src/components/button/Button.stories.mdx
+++ b/src/components/button/Button.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Button } from "../components/button";
-import { GnuiContainer, Flex } from "../components/container";
+import { Button } from ".";
+import { GnuiContainer, Flex } from "../container";
 
 <Meta title="Components/Button" component={Button} />
 

--- a/src/components/checkbox/Checkbox.stories.mdx
+++ b/src/components/checkbox/Checkbox.stories.mdx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Checkbox, CheckboxGroup } from "../components/checkbox";
+import { Checkbox, CheckboxGroup } from ".";
 
 <Meta title="Form/Checkbox" component={Checkbox} />
 

--- a/src/components/datepicker/Datepicker.stories.mdx
+++ b/src/components/datepicker/Datepicker.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 import { addDays } from 'date-fns';
 import { useState } from 'react';
-import { Datepicker } from "../components/datepicker";
+import { Datepicker } from ".";
 import { Calendar, DateRangePicker } from 'react-date-range';
 
 <Meta title="Components/Datepicker" component={Datepicker} />
@@ -22,20 +22,19 @@ type DatepickerProps = {
   <Story name="datepicker">
     {() => {
       const handleSelect = (date) => {
-        console.log(date); 
+        console.log(date);
       }
       return (
         <>
-           <Datepicker>
-             <Calendar
-                date={new Date()}
-                onChange={handleSelect}
-              />
-           </Datepicker>
+          <Datepicker>
+            <Calendar
+              date={new Date()}
+              onChange={(date) => handleSelect(date)}
+            />
+          </Datepicker>
         </>
       );
     }}
-   
   </Story>
 </Preview>
 
@@ -43,7 +42,7 @@ type DatepickerProps = {
   <Story name="daterangepicker">
     {() => {
       const handleSelect = (ranges) => {
-        console.log(ranges); 
+        console.log(ranges);
       }
       const [state, setState] = useState([
         {
@@ -54,8 +53,8 @@ type DatepickerProps = {
       ]);
       return (
         <>
-           <Datepicker>
-             <DateRangePicker
+          <Datepicker>
+            <DateRangePicker
               onChange={item => setState([item.selection])}
               showSelectionPreview={true}
               moveRangeOnFirstSelection={false}
@@ -63,11 +62,9 @@ type DatepickerProps = {
               ranges={state}
               direction="horizontal"
             />
-           </Datepicker>
+          </Datepicker>
         </>
       );
     }}
-   
   </Story>
 </Preview>
-

--- a/src/components/dropdown/Dropdown.stories.mdx
+++ b/src/components/dropdown/Dropdown.stories.mdx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Dropdown } from "../components/dropdown";
-import { GnuiContainer } from "../components/container";
-import { Spacer } from "../components/spacer";
-import { Text } from "../components/text";
+import { Dropdown } from ".";
+import { GnuiContainer } from "../container";
+import { Spacer } from "../spacer";
+import { Text } from "../text";
 
 <Meta title="Components/Dropdown" component={Dropdown} />
 

--- a/src/components/filter/Filter.stories.mdx
+++ b/src/components/filter/Filter.stories.mdx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Button } from "../components/button";
-import { Filter } from "../components/filter";
-import { Input } from "../components/input";
+import { Button } from "../button";
+import { Filter } from ".";
+import { Input } from "../input";
 import { Container, Row, Col } from "react-awesome-styled-grid";
 
 <Meta title="Components/Filter" component={Filter} />

--- a/src/components/form/Form.stories.mdx
+++ b/src/components/form/Form.stories.mdx
@@ -4,9 +4,9 @@ import {
   FormButtons,
   SubmitButton,
   CancelButton
-} from "../components/form";
-import { Input, Label, Description } from "../components/input";
-import { Heading } from "../components/heading";
+} from ".";
+import { Input, Label, Description } from "../input";
+import { Heading } from "../heading";
 
 <Meta title="Form/Form" component={Form} />
 

--- a/src/components/heading/Headings.stories.mdx
+++ b/src/components/heading/Headings.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Heading } from "../components/heading";
-import { GnuiContainer } from "../components/container";
-import { Text } from "../components/text";
+import { Heading } from ".";
+import { GnuiContainer } from "../container";
+import { Text } from "../text";
 
 <Meta title="Typography/Heading" component={Heading} />
 

--- a/src/components/icon/Icon.stories.mdx
+++ b/src/components/icon/Icon.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Icon } from "../components/icon";
-import { Container, Flex } from "../components/container";
-import { Heading } from "../components/heading";
+import { Icon } from ".";
+import { Container, Flex } from "../container";
+import { Heading } from "../heading";
 
 <Meta title="Components/Icon" component={Icon} />
 

--- a/src/components/input/Input.stories.mdx
+++ b/src/components/input/Input.stories.mdx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Input, Label, Description, Upload } from "../components/input";
-import { GnuiContainer } from "../components/container";
-import { Button } from "../components/button";
-import { Spacer } from "../components/spacer";
+import { Input, Label, Description, Upload } from ".";
+import { GnuiContainer } from "../container";
+import { Button } from "../button";
+import { Spacer } from "../spacer";
 
 <Meta title="Form/Input" component={Input} />
 

--- a/src/components/list/List.stories.mdx
+++ b/src/components/list/List.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { List } from "../components/list";
+import { List } from ".";
 
 <Meta title="Components/List" component={List} />
 
@@ -12,9 +12,9 @@ import { List } from "../components/list";
 - `horizontal`: `boolean` — _optional_ , default `false`
 - `unsorted`: `boolean` — _optional_ , default `false`
 - `hasDescription`: `boolean` - _optional_, default `false`
-- `items`: `array<{ 
-  title: string, 
-  description: string, 
+- `items`: `array<{
+  title: string,
+  description: string,
   rowChildren?: array
 }>  | string | number` — **required**
 - `spacing`: string - _optional_ used for custom spacing for list items
@@ -36,7 +36,7 @@ import { List } from "../components/list";
 
 <Preview>
   <Story name="unstyled list spacing">
-    <List 
+    <List
       spacing="0 0 1.15rem 0"
       items={[
         "List item",

--- a/src/components/loader/Loader.stories.mdx
+++ b/src/components/loader/Loader.stories.mdx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Loader } from "../components/loader";
-import { Spacer } from "../components/spacer";
-import { GnuiContainer, Flex } from "../components/container";
-import theme from "../theme";
+import { Loader } from ".";
+import { Spacer } from "../spacer";
+import { GnuiContainer, Flex } from "../container";
+import theme from "../../theme";
 
 <Meta title="Components/Loader" component={Loader} />
 

--- a/src/components/message/Message.stories.mdx
+++ b/src/components/message/Message.stories.mdx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Message } from "../components/message";
-import { Text } from "../components/text";
-import { Spacer } from "../components/spacer";
+import { Message } from ".";
+import { Text } from "../text";
+import { Spacer } from "../spacer";
 
 <Meta title="Components/Message" component={Message} />
 

--- a/src/components/modal/Modal.stories.mdx
+++ b/src/components/modal/Modal.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 import { useState } from "react";
-import { Modal, ModalConfirm } from "../components/modal";
-import { Button } from "../components/button";
+import { Modal, ModalConfirm } from ".";
+import { Button } from "../button";
 
 <Meta title="Components/Modal" component={Modal} />
 
@@ -32,7 +32,6 @@ import { Button } from "../components/button";
     {() => {
       const [isOpen, setOpen] = useState(false);
       const update = () => setOpen(!isOpen);
-
       return (
         <>
           <Button onClick={update}>Open modal</Button>
@@ -51,7 +50,6 @@ import { Button } from "../components/button";
         </>
       );
     }}
-
   </Story>
 </Preview>
 
@@ -62,7 +60,6 @@ import { Button } from "../components/button";
     {() => {
       const [isOpen, setOpen] = useState(false);
       const update = () => setOpen(!isOpen);
-
       return (
         <>
           <Button onClick={update}>Open modal</Button>
@@ -95,7 +92,6 @@ import { Button } from "../components/button";
         </>
       );
     }}
-
   </Story>
 </Preview>
 

--- a/src/components/multiselect/Multiselect.stories.mdx
+++ b/src/components/multiselect/Multiselect.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
 import { useState } from "react";
-import { Select } from "../components/multiselect";
-import theme from "../theme";
+import { Select } from ".";
+import theme from "../../theme";
 import chroma from 'chroma-js';
 
 <Meta title="Components/Select" component={Select} />
@@ -47,7 +47,7 @@ export interface SelectProps {
       ];
       return (
         <div style={{height: '150px'}}>
-          <Select 
+          <Select
             isMulti
             defaultValue={[options[1], options[2]]}
             options={options}
@@ -65,14 +65,14 @@ export interface SelectProps {
   <Story name="colors">
     {() => {
       const options = [
-        { value: 'chocolate', 
+        { value: 'chocolate',
           label: 'Chocolate'
         },
-        { value: 'strawberry', 
+        { value: 'strawberry',
           label: 'Strawberry',
           color: `${theme.colors.notification}`
            },
-        { value: 'vanilla', 
+        { value: 'vanilla',
           label: 'Vanilla',
           color: `${theme.colors.danger}`
         }
@@ -88,8 +88,8 @@ export interface SelectProps {
       };
       return (
         <div style={{height: '150px'}}>
-          <Select 
-            isMulti 
+          <Select
+            isMulti
             defaultValue={[options[1], options[2]]}
             options={options}
             styles={colorStyles}

--- a/src/components/navigation/Navigation.stories.mdx
+++ b/src/components/navigation/Navigation.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Navigation } from "../components/navigation";
-import Decos from "../utils/decos.tsx";
+import { Navigation } from ".";
+import Decos from "../../utils/decos.tsx";
 
 <Meta title="Components/Navigation" component={Navigation.Item} />
 

--- a/src/components/pagetitle/PageTitle.stories.mdx
+++ b/src/components/pagetitle/PageTitle.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { PageTitle, PageTitleBreadcrumbs } from "../components/pagetitle";
+import { PageTitle, PageTitleBreadcrumbs } from ".";
 
 
 <Meta title="Layout/PageTitleBreadcrumbs" component={PageTitleBreadcrumbs} />
@@ -36,8 +36,8 @@ interface PageTitleBreadcrumbsProps {
 
 <Preview>
   <Story name="breadcrumbs">
-    <PageTitleBreadcrumbs 
-      title="Page Heading" 
+    <PageTitleBreadcrumbs
+      title="Page Heading"
       list={[
         { label: "Home", uri: `#` },
         { label: "Hosts", uri: `#` },

--- a/src/components/pagination/Pagination.stories.mdx
+++ b/src/components/pagination/Pagination.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { PaginationBox } from "../components/pagination";
+import { PaginationBox } from ".";
 
 <Meta title="Components/Pagination" component={PaginationBox} />
 

--- a/src/components/piechart/PieChart.stories.mdx
+++ b/src/components/piechart/PieChart.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Text } from "../components/text";
-import { Flex } from "../components/container";
-import { PieChart } from "../components/piechart";
-import { SVGIcon } from "../components/svgicon";
+import { Text } from "../text";
+import { Flex } from "../container";
+import { PieChart } from ".";
+import { SVGIcon } from "../svgicon";
 
 <Meta title="Components/PieChart" component={PieChart} />
 

--- a/src/components/radiobutton/Radiobutton.stories.mdx
+++ b/src/components/radiobutton/Radiobutton.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Radio, RadioGroup } from "../components/radiobutton";
+import { Radio, RadioGroup } from ".";
 
 <Meta title="Form/Radiobutton" component={Radio} />
 

--- a/src/components/selectbutton/SelectButton.stories.mdx
+++ b/src/components/selectbutton/SelectButton.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { MultipleSelect, SelectButton } from "../components/selectbutton";
-import { Text } from "../components/text";
+import { MultipleSelect, SelectButton } from ".";
+import { Text } from "../text";
 import { useState } from "react";
 
 <Meta title="Components/SelectButton" component={MultipleSelect} />

--- a/src/components/sidebar/Sidebar.stories.mdx
+++ b/src/components/sidebar/Sidebar.stories.mdx
@@ -6,11 +6,11 @@ import {
   Description,
 } from "@storybook/addon-docs/blocks";
 import { useState } from "react";
-import { Button } from "../components/button";
-import { Sidebar } from "../components/sidebar";
+import { Button } from "../button";
+import { Sidebar } from ".";
 import { Container, Row, Col } from "react-awesome-styled-grid";
-import { Text } from "../components/text";
-import { Icon } from "../components/icon";
+import { Text } from "../text";
+import { Icon } from "../icon";
 
 <Meta title="Components/Sidebar" component={Sidebar} id="sidebar" />
 

--- a/src/components/spacer/Spacer.stories.mdx
+++ b/src/components/spacer/Spacer.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Spacer } from "../components/spacer";
-import { GnuiContainer, Flex } from "../components/container";
-import { Text } from "../components/text";
-import theme from "../theme";
+import { Spacer } from ".";
+import { GnuiContainer, Flex } from "../container";
+import { Text } from "../text";
+import theme from "../../theme";
 
 <Meta title="Layout/Spacer" component={Spacer} />
 

--- a/src/components/spinner/Spinner.stories.mdx
+++ b/src/components/spinner/Spinner.stories.mdx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Spinner } from "../components/spinner";
-import { Spacer } from "../components/spacer";
-import { Flex } from "../components/container";
-import theme from "../theme";
+import { Spinner } from ".";
+import { Spacer } from "../spacer";
+import { Flex } from "../container";
+import theme from "../../theme";
 
 <Meta title="Components/Spinner" component={Spinner} />
 

--- a/src/components/styleguide/Styleguide.stories.mdx
+++ b/src/components/styleguide/Styleguide.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Styleguide } from "../components/styleguide";
-import { Heading } from "../components/heading";
-import { GnuiContainer } from "../components/container";
-import { Spacer } from "../components/spacer";
-import theme from "../theme";
+import { Styleguide } from ".";
+import { Heading } from "../heading";
+import { GnuiContainer } from "../container";
+import { Spacer } from "../spacer";
+import theme from "../../theme";
 
 <Meta title="Foundation/Styleguide" component={Styleguide} />
 

--- a/src/components/svgicon/SVGIcon.stories.mdx
+++ b/src/components/svgicon/SVGIcon.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { SVGIcon } from "../components/svgicon";
-import { Container, Flex } from "../components/container";
+import { SVGIcon } from ".";
+import { Container, Flex } from "../container";
 import CopyToClipboard from "react-copy-to-clipboard";
 
 <Meta title="Components/SVGIcon" component={SVGIcon} />

--- a/src/components/switch/Switch.stories.mdx
+++ b/src/components/switch/Switch.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Switch } from "../components/switch";
-import { GnuiContainer } from "../components/container";
-import { Spacer } from "../components/spacer";
-import theme from "../theme";
+import { Switch } from ".";
+import { GnuiContainer } from "../container";
+import { Spacer } from "../spacer";
+import theme from "../../theme";
 
 <Meta title="Components/Switch" component={Switch} />
 

--- a/src/components/table/Table.stories.mdx
+++ b/src/components/table/Table.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Table } from "../components/table";
-import { Box } from "../components/box";
-import { Input } from "../components/input";
-import { Button } from "../components/button";
-import { Flex } from "../components/container";
+import { Table } from ".";
+import { Box } from "../box";
+import { Input } from "../input";
+import { Button } from "../button";
+import { Flex } from "../container";
 
 <Meta title="Components/Table" component={Table} />
 

--- a/src/components/tabs/Tabs.stories.mdx
+++ b/src/components/tabs/Tabs.stories.mdx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Tabs, Tab } from "../components/tabs";
-import { Button } from "../components/button";
-import { Text } from "../components/text";
+import { Tabs, Tab } from ".";
+import { Button } from "../button";
+import { Text } from "../text";
 
 <Meta title="Components/Tabs" component={Tabs} />
 

--- a/src/components/tag/Tag.stories.mdx
+++ b/src/components/tag/Tag.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Tag } from "../components/tag";
-import { GnuiContainer } from "../components/container";
+import { Tag } from ".";
+import { GnuiContainer } from "../container";
 
 <Meta title="Components/Tag" component={Tag} />
 

--- a/src/components/text/Text.stories.mdx
+++ b/src/components/text/Text.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Text } from "../components/text";
-import { GnuiContainer } from "../components/container";
+import { Text } from ".";
+import { GnuiContainer } from "../container";
 import title from "title";
 
 <Meta title="Typography/Text" component={Text} />

--- a/src/components/toast/Toast.stories.mdx
+++ b/src/components/toast/Toast.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Message, Toast } from "../components/toast";
-import { Button } from "../components/button";
+import { Message, Toast } from ".";
+import { Button } from "../button";
 import { toast, Slide, Zoom, Flip, Bounce } from 'react-toastify';
-import { Spacer } from "../components/spacer";
+import { Spacer } from "../spacer";
 
 <Meta title="Components/Toast" component={Toast} />
 
@@ -38,9 +38,9 @@ interface MessageProps {
     {() => {
       const customId = "custom-id-yes";
       const displayMsg = () => {
-        toast( 
-          <Message 
-            heading="Scanning..." 
+        toast(
+          <Message
+            heading="Scanning..."
           />,
           {toastId: customId}
         );
@@ -63,9 +63,9 @@ interface MessageProps {
   <Story name="severity">
     {() => {
       const displayMsgSeverity = () => {
-        toast( 
-          <Message 
-            heading="Scanning severity..." 
+        toast(
+          <Message
+            heading="Scanning severity..."
             message="Please wait a bit for the severity level"
           />
         );

--- a/src/components/toggle/Toggle.stories.mdx
+++ b/src/components/toggle/Toggle.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Toggle } from "../components/toggle";
+import { Toggle } from ".";
 import { useState } from "react";
 
 <Meta title="Components/Toggle" component={Toggle} />
@@ -8,7 +8,7 @@ import { useState } from "react";
 
 #### Props
 
-- `name`: `string` **required** 
+- `name`: `string` **required**
 - `labelText`: `string` **required**
 - `toggleValue`: `boolean` — _optional_
 - `size`: `string` — _optional_ - small-sized SelectButton

--- a/src/components/tooltip/Tooltip.stories.mdx
+++ b/src/components/tooltip/Tooltip.stories.mdx
@@ -1,10 +1,10 @@
 import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
-import { Tooltip } from "../components/tooltip";
-import { Text } from "../components/text";
-import {  Flex } from "../components/container";
-import { Button } from "../components/button";
-import { SVGIcon } from "../components/svgicon";
-import { Input } from "../components/input";
+import { Tooltip } from ".";
+import { Text } from "../text";
+import {  Flex } from "../container";
+import { Button } from "../button";
+import { SVGIcon } from "../svgicon";
+import { Input } from "../input";
 
 <Meta title="Components/Tooltip" component={Tooltip} />
 


### PR DESCRIPTION
## Task

#210 

## Why?

Right now, all of the *.stories.mdx files reside inside src/stories folder,
please move every story to its component folder.

## What Changed

* [X] Move all component stories to their respective component files
* [X] Update imports
* [X] Fix whitespace causing mdx unexpected tokens after moving files

I didn't move Application, Dashboard, Grid, Snow, TotalSpend, and Wizard, since they pull together multiple components and are not tied to a specific folder in the components folder. They still show up in the stories documentation.