### PR TITLE
[Docs] Add docs for navigation, spinner and textarea

### DIFF
--- a/src/components/navigation/Navigation.stories.mdx
+++ b/src/components/navigation/Navigation.stories.mdx
@@ -14,11 +14,11 @@ import { Flex } from "../container";
 
 ## Navigation.Container properties
 
-|  properties | required | type                                  | description               |
-| ----------: | :------: | :------------------------------------ | :------------------------ |
-|    children |   true   | <code>`Array<Navigation.Item>`</code> |                           |
-|   secondary |  false   | boolean                               | styles for secondary menu |
-| popoverMenu |  false   | boolean                               | styles for popover menu   |
+|  properties | required | type                                  | description                                    |
+| ----------: | :------: | :------------------------------------ | :--------------------------------------------- |
+|    children |   true   | <code>`Array<Navigation.Item>`</code> |                                                |
+|   secondary |  false   | boolean                               | display items as full-width rows               |
+| popoverMenu |  false   | boolean                               | display items as full-width rows with svg icon |
 
 ## Navigation.Item properties
 

--- a/src/components/navigation/Navigation.stories.mdx
+++ b/src/components/navigation/Navigation.stories.mdx
@@ -10,17 +10,21 @@ import { Flex } from "../container";
 
 <Meta title="Components/Navigation" component={Navigation.Item} />
 
-<Preview>
-  <Story name="single link">
-    {() => {
-      return (
-        <Navigation.Item as="a" href="http://google.com" target="_blank">
-          Google
-        </Navigation.Item>
-      );
-    }}
-  </Story>
-</Preview>
+# Navigation
+
+## Navigation.Container properties
+
+|  properties | required | type                                  | description               |
+| ----------: | :------: | :------------------------------------ | :------------------------ |
+|    children |   true   | <code>`Array<Navigation.Item>`</code> |                           |
+|   secondary |  false   | boolean                               | styles for secondary menu |
+| popoverMenu |  false   | boolean                               | styles for popover menu   |
+
+## Navigation.Item properties
+
+| properties | required | type                             | description |
+| ---------: | :------: | :------------------------------- | :---------- |
+|   children |   true   | <code>`ReactElement<any>`</code> |             |
 
 ### Primary Navigation
 

--- a/src/components/spinner/Spinner.stories.mdx
+++ b/src/components/spinner/Spinner.stories.mdx
@@ -11,7 +11,7 @@ import theme from "../../theme";
 
 > Used only in source code of Loader, Button and Input
 
-## Spinner Props
+## Spinner properties
 
 | properties | required | type                                                                                                           | description |
 | ---------: | :------: | :------------------------------------------------------------------------------------------------------------- | :---------- |

--- a/src/components/spinner/Spinner.stories.mdx
+++ b/src/components/spinner/Spinner.stories.mdx
@@ -17,7 +17,7 @@ import theme from "../../theme";
 | ---------: | :------: | :------------------------------------------------------------------------------------------------------------- | :---------- |
 |       size |  false   | <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>, <code>xxl</code>                           |             |
 |      color |  false   | <code>success</code>, <code>danger</code>, <code>warning</code>, <code>notification</code>, <code>white</code> |             |
-|      ninja |  false   | boolean                                                                                                        |             |
+|      ninja |  false   | boolean                                                                                                        | displays spinner as a ninja animation |
 
 ## Default
 

--- a/src/components/spinner/Spinner.stories.mdx
+++ b/src/components/spinner/Spinner.stories.mdx
@@ -9,11 +9,15 @@ import theme from "../../theme";
 
 # Spinner
 
-## Props
+> Used only in source code of Loader, Button and Input
 
-> - `size`: `string` — **optional**: `sm` | `md` | `lg` | `xl` | `xxl`
-> - `color`: `string` — **optional**: `success` | `danger` | `warning` | `notification` | `white`
-> - `ninja`: `boolean` — **optional**
+## Spinner Props
+
+| properties | required | type                                                                                                           | description |
+| ---------: | :------: | :------------------------------------------------------------------------------------------------------------- | :---------- |
+|       size |  false   | <code>sm</code>, <code>md</code>, <code>lg</code>, <code>xl</code>, <code>xxl</code>                           |             |
+|      color |  false   | <code>success</code>, <code>danger</code>, <code>warning</code>, <code>notification</code>, <code>white</code> |             |
+|      ninja |  false   | boolean                                                                                                        |             |
 
 ## Default
 

--- a/src/components/textarea/Textarea.stories.mdx
+++ b/src/components/textarea/Textarea.stories.mdx
@@ -10,9 +10,12 @@ import theme from "../../theme";
 
 # Textarea
 
-#### Props
+## Textarea properties
 
-- `status`: `string` — _optional_ - color indicator status for SelectButton
+| properties | required | type                                      | description                             |
+| ---------: | :------: | :---------------------------------------- | :-------------------------------------- |
+|     status |  false   | <code>`success`</code>, <code>`error`</code> | color indicator status for SelectButton |
+|      small |  false   | boolean                                   | small size styles                       |
 
 ## default
 
@@ -43,6 +46,7 @@ import theme from "../../theme";
           <GnuiContainer>
             <Textarea status={status} />
           </GnuiContainer>
+          <Spacer height="1rem" />
           <GnuiContainer>
             <Button
               size="small"


### PR DESCRIPTION
<img width="1113" alt="Zrzut ekranu 2021-04-15 o 11 20 13" src="https://user-images.githubusercontent.com/58164749/114846071-9b5f1d80-9ddc-11eb-9cbe-ee1e6096b6fb.png">

<img width="1065" alt="Zrzut ekranu 2021-04-15 o 14 19 26" src="https://user-images.githubusercontent.com/58164749/114867963-ae321c00-9df5-11eb-8f98-8107807b1646.png">

<img width="1080" alt="Zrzut ekranu 2021-04-15 o 14 24 30" src="https://user-images.githubusercontent.com/58164749/114868966-c48ca780-9df6-11eb-9289-e5306a43b87d.png">
