### PR TITLE
Remove bottom tab element when not needed

### DIFF
--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -272,7 +272,7 @@ export const Tabs: FunctionComponent<TabsProps> = ({
           return (
             <React.Fragment key={key}>
               <TabsContent>{children}</TabsContent>
-              {wizard && (
+              {buttons != null && (
                 <TabsStatusButtons buttonsJustify={buttonsJustify}>
                   {buttons}
                 </TabsStatusButtons>


### PR DESCRIPTION
- Remove empty element when consumer doesn't want to use it (no buttons element provided)