### PR TITLE
Fix Theme switcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "MIT",
       "dependencies": {
         "@types/react-date-range": "^0.94.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/theme/switcher.ts
+++ b/src/theme/switcher.ts
@@ -18,14 +18,14 @@ function isThemeValue(value: string): value is keyof typeof THEME_OPTIONS {
   return value === "LIGHT" || value === "DARK";
 }
 
-const savedThemeValue = localStorage.getItem("NC_GNUI_THEME") ?? "";
-const defaultTheme = isThemeValue(savedThemeValue)
-  ? THEME_OPTIONS[savedThemeValue]
-  : getPreferredBrowserTheme();
-
 export const useThemeSwitcher = () => {
-  const [currentTheme, setCurrentTheme] =
-    React.useState<THEME_OPTIONS>(defaultTheme);
+  const [currentTheme, setCurrentTheme] = React.useState<THEME_OPTIONS>(() => {
+    const savedThemeValue = window.localStorage.getItem("NC_GNUI_THEME") ?? "";
+
+    return isThemeValue(savedThemeValue)
+      ? THEME_OPTIONS[savedThemeValue]
+      : getPreferredBrowserTheme();
+  });
 
   React.useEffect(() => {
     const newTheme = currentTheme === THEME_OPTIONS.DARK ? dark : light;


### PR DESCRIPTION
# What

- properly initialize the initial state of theme switcher, fix bug with old state being preserved while multiple `useThemeSwitcher` are used in one app

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
