### PR TITLE
Removed Storybook's deprecated Preview in favor of Canvas

### DIFF
--- a/DOCS_GUIDE.md
+++ b/DOCS_GUIDE.md
@@ -5,7 +5,7 @@ I decide to wrote this short guide, because I'd love if we will write consistent
 ### Add JavaScript imports
 
 ```javascript
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { COMPONENT_NAME } from "../components/COMPONENT_NAME";
 ```
 
@@ -16,11 +16,11 @@ Add main header as COMPONENT_NAME and then write shortest and easiest variant of
 ```markdown
 # COMPONENT_NAME
 
-<Preview>
-  <Story name="DEFAULT_COMPONENT>
+<Canvas>
+  <Story name="DEFAULT_COMPONENT">
     <COMPONENT_NAME />
   </Story>
-</Preview>
+</Canvas>
 ```
 
 ### Props
@@ -46,11 +46,11 @@ Describe all props in verbose way with examples if needed.
 
 > `prop: type` — <Provide some description if needed>
 
-<Preview>
+<Canvas>
   <Story name='default'>
     <COMPONENT_NAME prop='PROP_NAME' />
   </Story>
-</Preview>
+</Canvas>
 ```
 
 #### Example:
@@ -60,7 +60,7 @@ Describe all props in verbose way with examples if needed.
 
 > `color?: string` — color takes value from `theme` if exists or use provided value as is.
 
-<Preview>
+<Canvas>
   <Story name='color'>
     <Box color='danger'>
       This text will get color from theme.
@@ -69,5 +69,5 @@ Describe all props in verbose way with examples if needed.
       As crimson doesn't exist in theme text will be #DC143C.
     </Box>
   </Story>
-</Preview>
+</Canvas>
 ```

--- a/src/components/accordion/Accordion.stories.mdx
+++ b/src/components/accordion/Accordion.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Accordion, AccordionHeader, AccordionItem } from "./";
 
 <Meta title="Components/Accordion" component={Accordion} />
@@ -13,14 +13,14 @@ import { Accordion, AccordionHeader, AccordionItem } from "./";
 | ---------: | :------: | :------------------------- | :---------- |
 |   children |   true   | AccordionHeader components |             |
 
-<Preview>
+<Canvas>
   <Story name="accordion">
     <Accordion>
       <AccordionHeader title="Header 1" description="description..." />
       <AccordionHeader title="Header 2" description="description..." />
     </Accordion>
   </Story>
-</Preview>
+</Canvas>
 
 # AccordionHeader
 
@@ -40,7 +40,7 @@ import { Accordion, AccordionHeader, AccordionItem } from "./";
 | ---------: | :------: | :--- | :---------- |
 |   children |   true   | any  |             |
 
-<Preview>
+<Canvas>
   <Story name="accordion header">
     <Accordion>
       <AccordionHeader title="Header 1" description="description...">
@@ -54,4 +54,4 @@ import { Accordion, AccordionHeader, AccordionItem } from "./";
       </AccordionHeader>
     </Accordion>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/barchart/BarChart.stories.mdx
+++ b/src/components/barchart/BarChart.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { BarChart } from "./";
 import theme from "../../theme";
 
@@ -24,7 +24,7 @@ import theme from "../../theme";
 
 ## Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const values = [
@@ -44,4 +44,4 @@ import theme from "../../theme";
       return <BarChart values={values} />;
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/box/Box.stories.mdx
+++ b/src/components/box/Box.stories.mdx
@@ -2,7 +2,7 @@ import {
   Meta,
   Title,
   Story,
-  Preview,
+  Canvas,
   Description,
   Props,
 } from "@storybook/addon-docs/blocks";
@@ -41,17 +41,17 @@ import theme from "../../theme";
 
 ### default
 
-<Preview>
+<Canvas>
   <Story name="box">
     <Box>Default box</Box>
   </Story>
-</Preview>
+</Canvas>
 
 ### boxStyle
 
 > boxStyle: `lightGrey` | `grey`
 
-<Preview>
+<Canvas>
   <Story name="boxStyle">
     <Flex justifyContent="space-evenly">
       <Box boxStyle="lightGrey">Light grey box</Box>
@@ -60,23 +60,23 @@ import theme from "../../theme";
       <Box boxStyle="grey">Grey box</Box>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### dark
 
 > dark: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="dark">
     <Box dark>Dark box</Box>
   </Story>
-</Preview>
+</Canvas>
 
 ### border
 
 > `border`: `string` - [`default`, `medium`, `bold`, `grey`, `disabled`, `darkenGrey`, `dark`, `success`, `danger`, `warning`, `notification`, `transparent`] or a custom border
 
-<Preview>
+<Canvas>
   <Story name="border">
     <GnuiContainer>
       <Box border="default">Default border</Box>
@@ -90,13 +90,13 @@ import theme from "../../theme";
       <Box border="1px solid violet">Custom border</Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### radius
 
 > `radius`: `string` — [`small`, `default`, `large`]
 
-<Preview>
+<Canvas>
   <Story name="radius">
     <GnuiContainer>
       <Box radius="small" border="disabled">
@@ -112,13 +112,13 @@ import theme from "../../theme";
       </Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### innerSpacing
 
 > `innerSpacing`: `string` — [`spacing01`, `spacing02`, `spacing03`, `spacing04`, `spacing05`, `spacing06`, `spacing07`]
 
-<Preview>
+<Canvas>
   <Story name="innerSpacing">
     <GnuiContainer>
       <Box innerSpacing="spacing04">Box with spacing04 innerSpacing prop</Box>
@@ -126,13 +126,13 @@ import theme from "../../theme";
       <Box innerSpacing="spacing07">Box with spacing07 innerSpacing prop</Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### shadow
 
 > `shadow`: `string` — [`shadow01`, `shadow02`, `shadow03`, `shadow04`]
 
-<Preview>
+<Canvas>
   <Story name="shadow">
     <GnuiContainer>
       <Box shadow="shadow01">Box with shadow01 shadow prop</Box>
@@ -144,13 +144,13 @@ import theme from "../../theme";
       <Box shadow="shadow04">Box with shadow04 shadow prop</Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### color
 
 > `color`: `string` — GNUI as first looks for the value in `theme.colors` and if color doesn't exist there `color` will be used as is.
 
-<Preview>
+<Canvas>
   <Story name="color">
     <GnuiContainer>
       <Box color={theme.color.text.error}>Danger color (from theme)</Box>
@@ -164,13 +164,13 @@ import theme from "../../theme";
       <Box color="#5ead9d">#5ead9d color</Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### backgroundColor
 
 > `backgroundColor`: `string` — GNUI as first looks for the value in `theme.colors` and if color doesn't exist there `color` will be used as is.
 
-<Preview>
+<Canvas>
   <Story name="background">
     <GnuiContainer>
       <Box backgroundColor={theme.color.background.error} color="white">
@@ -190,4 +190,4 @@ import theme from "../../theme";
       </Box>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/components/breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Breadcrumbs } from ".";
 
 <Meta title="Components/Breadcrumbs" component={Breadcrumbs} />
@@ -21,7 +21,7 @@ import { Breadcrumbs } from ".";
 |      label |   true   | string |             |
 |        uri |   true   | string |             |
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Breadcrumbs
       list={[
@@ -31,4 +31,4 @@ import { Breadcrumbs } from ".";
       ]}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/button/Button.stories.mdx
+++ b/src/components/button/Button.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Button } from ".";
 import { GnuiContainer, Flex } from "../container";
 
@@ -25,30 +25,30 @@ import { GnuiContainer, Flex } from "../container";
 
 ## default button
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Button>Default button</Button>
   </Story>
-</Preview>
+</Canvas>
 
 ## severity
 
 > severity: `medium` | `low`
 
-<Preview>
+<Canvas>
   <Story name="button/severity">
     <Flex justifyContent="space-evenly">
       <Button severity="medium">Secondary button</Button>
       <Button severity="low">Button for use as an icon</Button>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## size
 
 > size: `sm` | `md`
 
-<Preview>
+<Canvas>
   <Story name="size">
     <Flex justifyContent="space-evenly">
       <Button size="sm">Size SM</Button>
@@ -56,13 +56,13 @@ import { GnuiContainer, Flex } from "../container";
       <Button>Size Default</Button>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## icon
 
 > `icon`: `string`
 
-<Preview>
+<Canvas>
   <Story name="icons">
     <Flex justifyContent="space-evenly">
       <Button icon="plus" severity="low">
@@ -71,13 +71,13 @@ import { GnuiContainer, Flex } from "../container";
       <Button icon="plus" severity="low" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## iconRight
 
 > `iconRight`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="iconRight">
     <Flex justifyContent="space-evenly">
       <Button iconRight severity="low" icon="trash">
@@ -85,13 +85,13 @@ import { GnuiContainer, Flex } from "../container";
       </Button>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## initialState
 
 > `initialState`: `success` | `error` | `loading`
 
-<Preview>
+<Canvas>
   <Story name="initialState">
     <Flex justifyContent="space-evenly">
       <Button initialState="loading">Save changes</Button>
@@ -102,13 +102,13 @@ import { GnuiContainer, Flex } from "../container";
       <Button initialState="error" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## color
 
 > `color`: `string`
 
-<Preview>
+<Canvas>
   <Story name="color">
     <Flex justifyContent="space-evenly">
       <Button color="danger" icon="danger">
@@ -123,23 +123,23 @@ import { GnuiContainer, Flex } from "../container";
       <Button color="#FF1493">HEX color</Button>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## disabled
 
 > `disabled`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="disabled">
     <Button disabled icon="save">
       Disabled button
     </Button>
   </Story>
-</Preview>
+</Canvas>
 
 ## Custom spacing
 
-<Preview>
+<Canvas>
   <Story name="custom-spacing">
     <GnuiContainer>
       <p>
@@ -149,25 +149,25 @@ import { GnuiContainer, Flex } from "../container";
       </p>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ## linkTo
 
 > linkTo: `string`
 
-<Preview>
+<Canvas>
   <Story name="button link">
     <Button linkTo="http://google.com" target="_blank">
       Link to
     </Button>
   </Story>
-</Preview>
+</Canvas>
 
 ## display
 
 > display: `flex` | `inline-flex`
 
-<Preview>
+<Canvas>
   <Story name="button link flex">
     <Button display="flex" linkTo="http://google.com" target="_blank">
       Button
@@ -181,4 +181,4 @@ import { GnuiContainer, Flex } from "../container";
       Button
     </Button>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/checkbox/Checkbox.stories.mdx
+++ b/src/components/checkbox/Checkbox.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Checkbox, CheckboxGroup } from ".";
 import { IndeterminateCheckbox } from ".";
 
@@ -16,29 +16,29 @@ import { IndeterminateCheckbox } from ".";
 
 ### Default
 
-<Preview>
+<Canvas>
   <Story name="simple">
     <Checkbox id="checkbox-1" labelText="GNUI Checkbox" />
   </Story>
-</Preview>
+</Canvas>
 
 ### withoutLabel
 
 > Default input type `checkbox` without Label with larger clickable surface.
 
-<Preview>
+<Canvas>
   <Story name="withoutLabel">
     <Checkbox withoutLabel id="checkbox-5" />
   </Story>
-</Preview>
+</Canvas>
 
 ### isIndeterminate
 
-<Preview>
+<Canvas>
   <Story name="isIndeterminate">
     <IndeterminateCheckbox id="321312" indeterminate={true} />
   </Story>
-</Preview>
+</Canvas>
 
 # CheckboxGroup
 
@@ -48,7 +48,7 @@ import { IndeterminateCheckbox } from ".";
 | ---------: | :------: | :------------------ | :---------- |
 |   children |  false   | `ReactElement<any>` |             |
 
-<Preview>
+<Canvas>
   <Story name="group">
     {() => {
       const [value, setValue] = React.useState({
@@ -73,4 +73,4 @@ import { IndeterminateCheckbox } from ".";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/checkboxTree/CheckboxTree.stories.mdx
+++ b/src/components/checkboxTree/CheckboxTree.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { CheckboxTree } from "./CheckboxTree.tsx";
 
 <Meta title="Forms/CheckboxTree" component={CheckboxTree} />
@@ -20,7 +20,7 @@ import { CheckboxTree } from "./CheckboxTree.tsx";
 
 ### Default
 
-<Preview>
+<Canvas>
   <Story name="simple">
     <CheckboxTree
       expanded={["meat", "meat->pork"]}
@@ -74,4 +74,4 @@ import { CheckboxTree } from "./CheckboxTree.tsx";
       ]}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/datepicker/Datepicker.stories.mdx
+++ b/src/components/datepicker/Datepicker.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { addDays } from "date-fns";
 import { Datepicker } from ".";
 import { Calendar, DateRangePicker } from "react-date-range";
@@ -17,7 +17,7 @@ type DatepickerProps = {
 
 > Primary button is default as well.
 
-<Preview>
+<Canvas>
   <Story name="datepicker">
     {() => {
       const handleSelect = (date) => {
@@ -30,9 +30,9 @@ type DatepickerProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="daterangepicker">
     {() => {
       const handleSelect = (ranges) => {
@@ -59,4 +59,4 @@ type DatepickerProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/dropdown/Dropdown.stories.mdx
+++ b/src/components/dropdown/Dropdown.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Dropdown } from ".";
 import { GnuiContainer } from "../container";
 import { Spacer } from "../spacer";
@@ -25,7 +25,7 @@ import { Text } from "../text";
 
 ## dropdown with search
 
-<Preview>
+<Canvas>
   <Story name="dropdown">
     {() => {
       const options = [
@@ -58,11 +58,11 @@ import { Text } from "../text";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## dropdown without search
 
-<Preview>
+<Canvas>
   <Story name="dropdown without search">
     {() => {
       const options = [
@@ -96,4 +96,4 @@ import { Text } from "../text";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/extendedPagination/ExtendedPagination.stories.mdx
+++ b/src/components/extendedPagination/ExtendedPagination.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { ExtendedPaginationBox } from ".";
 
 <Meta title="Components/ExtendedPagination" component={ExtendedPaginationBox} />
@@ -20,58 +20,58 @@ import { ExtendedPaginationBox } from ".";
 
 ### first page
 
-<Preview>
+<Canvas>
   <Story name="first-page">
     <ExtendedPaginationBox count={400} from={0} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### second page
 
-<Preview>
+<Canvas>
   <Story name="second-page">
     <ExtendedPaginationBox count={400} from={20} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### middle
 
-<Preview>
+<Canvas>
   <Story name="middle">
     <ExtendedPaginationBox count={400} from={240} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### second to last page
 
-<Preview>
+<Canvas>
   <Story name="second-to-last-page">
     <ExtendedPaginationBox count={400} from={360} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### last page
 
-<Preview>
+<Canvas>
   <Story name="last-page">
     <ExtendedPaginationBox count={400} from={380} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### different edge cases in the middle of the pagination
 
-<Preview>
+<Canvas>
   <Story name="edge-cases">
     <ExtendedPaginationBox count={400} from={80} size={20} setPage={0} setSize={20} />
     <ExtendedPaginationBox count={400} from={100} size={20} setPage={0} setSize={20} />
     <ExtendedPaginationBox count={400} from={280} size={20} setPage={0} setSize={20} />
     <ExtendedPaginationBox count={400} from={300} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ### short pagination
 
-<Preview>
+<Canvas>
   <Story name="short">
     <ExtendedPaginationBox count={60} from={0} size={20} setPage={0} setSize={20} />
     <ExtendedPaginationBox count={60} from={40} size={20} setPage={0} setSize={20} />
@@ -85,11 +85,11 @@ import { ExtendedPaginationBox } from ".";
     <ExtendedPaginationBox count={140} from={20} size={20} setPage={0} setSize={20} />
     <ExtendedPaginationBox count={140} from={60} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ## small
 
-<Preview>
+<Canvas>
   <Story name="small">
     <ExtendedPaginationBox
       small
@@ -100,4 +100,4 @@ import { ExtendedPaginationBox } from ".";
       setSize={20}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/form/Form.stories.mdx
+++ b/src/components/form/Form.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Form, FormButtons, SubmitButton, CancelButton } from ".";
 import { Input, Label, Description } from "../input";
 import { Heading } from "../heading";
@@ -7,7 +7,7 @@ import { Heading } from "../heading";
 
 # Form
 
-<Preview>
+<Canvas>
   <Story name="form">
     <Form>
       <Heading level={3} marginBottom="spacing04">
@@ -48,4 +48,4 @@ import { Heading } from "../heading";
       </FormButtons>
     </Form>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/heading/Headings.stories.mdx
+++ b/src/components/heading/Headings.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Heading } from ".";
 import { GnuiContainer } from "../container";
 import theme from "../../theme";
@@ -9,11 +9,11 @@ import theme from "../../theme";
 
 > Simple heading is styled `h1` tag and looks like below.
 
-<Preview>
+<Canvas>
   <Story name="simple">
     <Heading>Simple heading</Heading>
   </Story>
-</Preview>
+</Canvas>
 
 ## Heading properties
 
@@ -27,7 +27,7 @@ import theme from "../../theme";
 
 `level`: `number` — from 1 to 6
 
-<Preview>
+<Canvas>
   <Story name="levels">
     <GnuiContainer>
       <Heading level={1}>Heading with level prop</Heading>
@@ -38,13 +38,13 @@ import theme from "../../theme";
       <Heading level={6}>Heading with level prop</Heading>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### marginBottom
 
 `marginBottom`: `string` — spacing00 | spacing01 | spacing02 | spacing03 | spacing04 | spacing05 | spacing06 | spacing07 | spacing08
 
-<Preview>
+<Canvas>
   <Story name="margins">
     <GnuiContainer>
       <Heading level={4} marginBottom="spacing08">
@@ -76,13 +76,13 @@ import theme from "../../theme";
       </Heading>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### color
 
 `color`: `string` — can be in HEX/named colors formats according to [X11 Colors](https://en.wikipedia.org/wiki/X11_color_names)
 
-<Preview>
+<Canvas>
   <GnuiContainer>
     <Heading color="palevioletred">Named color</Heading>
     <Heading color="#6495ED">HEX color</Heading>
@@ -91,4 +91,4 @@ import theme from "../../theme";
     <Heading color={theme.color.text.warning}>Warning color</Heading>
     <Heading color={theme.color.text.info}>Notification color</Heading>
   </GnuiContainer>
-</Preview>
+</Canvas>

--- a/src/components/input/Input.stories.mdx
+++ b/src/components/input/Input.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Input, Label, Description, Upload } from ".";
 import { GnuiContainer } from "../container";
 import { Button } from "../button";
@@ -11,11 +11,11 @@ import { InputSearch } from "./InputSearch.tsx";
 
 > Inputs type defaults to `text`.
 
-<Preview>
+<Canvas>
   <Story name="input">
     <Input name="input" placeholder="Placeholder" title="Title" />
   </Story>
-</Preview>
+</Canvas>
 
 ## Input properties
 
@@ -40,11 +40,11 @@ import { InputSearch } from "./InputSearch.tsx";
 
 > `name`: `string`
 
-<Preview>
+<Canvas>
   <Story name="name">
     <Input name="Thats my name" title="That's my title" />
   </Story>
-</Preview>
+</Canvas>
 
 ### type
 
@@ -52,7 +52,7 @@ import { InputSearch } from "./InputSearch.tsx";
 
 For now it works good for two types: default `text` and `search`. The second one displays an icon before text. **TBC**
 
-<Preview>
+<Canvas>
   <Story name="type">
     <Input
       name="search-input"
@@ -61,7 +61,7 @@ For now it works good for two types: default `text` and `search`. The second one
       title="Search input"
     />
   </Story>
-</Preview>
+</Canvas>
 
 ### placeholder
 
@@ -73,17 +73,17 @@ Placeholder text inside input element
 
 > `disabled`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="disabled">
     <Input name="disabled-input" placeholder="Disabled input" disabled />
   </Story>
-</Preview>
+</Canvas>
 
 ### required
 
 > `required`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="required">
     <>
       <Label name="Label" htmlFor="required-id" required />
@@ -94,45 +94,45 @@ Placeholder text inside input element
       />
     </>
   </Story>
-</Preview>
+</Canvas>
 
 ### small
 
-<Preview>
+<Canvas>
   <Story name="small">
     <>
       <Label name="Label" htmlFor="small-id" required />
       <Input name="required-input" id="small-id" placeholder="Small" small />
     </>
   </Story>
-</Preview>
+</Canvas>
 
 ### upload
 
-<Preview>
+<Canvas>
   <Story name="upload">
     <>
       <Upload name="upload" placeholder="Select a file to upload" />
     </>
   </Story>
-</Preview>
+</Canvas>
 
 ### icon
 
-<Preview>
+<Canvas>
   <Story name="icon">
     <>
       <Label name="Label" htmlFor="icon-id" required />
       <Input name="required-input" id="icon-id" placeholder="" icon="sidebar" />
     </>
   </Story>
-</Preview>
+</Canvas>
 
 ### status
 
 > `status`: `success | error`
 
-<Preview>
+<Canvas>
   <Story name="status">
     {() => {
       const [status, setStatus] = React.useState("success");
@@ -161,13 +161,13 @@ Placeholder text inside input element
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Label and description
 
 > You can add `Label` before `Input` and `Description` after it. Labels name is what exactly will be displayed as a text above `Input`.
 
-<Preview>
+<Canvas>
   <Story name="label & description">
     <GnuiContainer>
       <Label name="Label" htmlFor="description-id" />
@@ -179,11 +179,11 @@ Placeholder text inside input element
       <Description>Inputs description</Description>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### clear
 
-<Preview>
+<Canvas>
   <Story name="clear">
     <>
       <Label name="Label" htmlFor="clear-id" required />
@@ -199,11 +199,11 @@ Placeholder text inside input element
       />
     </>
   </Story>
-</Preview>
+</Canvas>
 
 ### search
 
-<Preview>
+<Canvas>
   <Story name="search">
     <>
       <InputSearch
@@ -213,4 +213,4 @@ Placeholder text inside input element
       />
     </>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/list/List.stories.mdx
+++ b/src/components/list/List.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { List } from ".";
 
 <Meta title="Components/List" component={List} />
@@ -21,35 +21,35 @@ import { List } from ".";
 
 > Basic unstyled list. Takes a string or number array
 
-<Preview>
+<Canvas>
   <Story name="default">
     <List items={["List item", "Second list item"]} />
   </Story>
-</Preview>
+</Canvas>
 
 ### spacing
 
 > Default list with custom spacing
 
-<Preview>
+<Canvas>
   <Story name="spacing">
     <List spacing="0 0 1.15rem 0" items={["List item", "Second list item"]} />
   </Story>
-</Preview>
+</Canvas>
 
 ### horizontal
 
 > Horizontal list. Takes a string or number array
 
-<Preview>
+<Canvas>
   <Story name="horizontal">
     <List horizontal items={["List item", "Second list item"]} />
   </Story>
-</Preview>
+</Canvas>
 
 ### unordered
 
-<Preview>
+<Canvas>
   <Story name="unordered">
     <List
       unordered
@@ -59,13 +59,13 @@ import { List } from ".";
       ]}
     />
   </Story>
-</Preview>
+</Canvas>
 
 ### hasDescription
 
 > List with description.
 
-<Preview>
+<Canvas>
   <Story name="hasDescription">
     <List
       hasDescription
@@ -78,4 +78,4 @@ import { List } from ".";
       ]}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/loader/Loader.stories.mdx
+++ b/src/components/loader/Loader.stories.mdx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Loader } from ".";
 import { Spacer } from "../spacer";
 import { GnuiContainer, Flex } from "../container";
@@ -21,17 +21,17 @@ import theme from "../../theme";
 
 > By default Loader position is: top, center
 
-<Preview>
+<Canvas>
   <Story name="default" height="300px">
     <Loader />
   </Story>
-</Preview>
+</Canvas>
 
 ## position
 
 > `position`: `top-left` | `top-right` | `bottom-right` | `bottom-center` | `bottom-left` — **optional**
 
-<Preview>
+<Canvas>
   <Story name="position" height="300px">
     <GnuiContainer>
       <Loader position="top-left" />
@@ -42,28 +42,28 @@ import theme from "../../theme";
       <Loader position="bottom-left" />
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ## inContent
 
 > `inContent`: `boolean` — **optional**
 
-<Preview>
+<Canvas>
   <Story name="inContent">
     <GnuiContainer>
       <Loader inContent />
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ## isBackground
 
 > `isBackground`: `boolean` — **optional**
 
-<Preview>
+<Canvas>
   <Story name="isBackground" height="300px">
     <GnuiContainer>
       <Loader isBackground />
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/message/Message.stories.mdx
+++ b/src/components/message/Message.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Message } from ".";
 import { Text } from "../text";
 import { Spacer } from "../spacer";
@@ -19,7 +19,7 @@ import { Spacer } from "../spacer";
 
 ## default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Message>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
@@ -29,11 +29,11 @@ import { Spacer } from "../spacer";
       velit esse cillum dolore eu fugiat nulla pariatur.
     </Message>
   </Story>
-</Preview>
+</Canvas>
 
 ## status
 
-<Preview>
+<Canvas>
   <Story name="status">
     <>
       <Message status="success" image="success">
@@ -53,4 +53,4 @@ import { Spacer } from "../spacer";
       </Message>
     </>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/modal/Modal.stories.mdx
+++ b/src/components/modal/Modal.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Modal, ModalConfirm } from ".";
 import { Button } from "../button";
 
@@ -30,7 +30,7 @@ import { Button } from "../button";
 
 ### Basic modal
 
-<Preview>
+<Canvas>
   <Story name="basic modal">
     {() => {
       const [isOpen, setOpen] = React.useState(false);
@@ -53,11 +53,11 @@ import { Button } from "../button";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Modal with actions
 
-<Preview>
+<Canvas>
   <Story name="modal with actions">
     {() => {
       const [isOpen, setOpen] = React.useState(false);
@@ -93,11 +93,11 @@ import { Button } from "../button";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Modal Confirm
 
-<Preview>
+<Canvas>
   <Story name="confirm modal">
     {() => {
       const [isOpen, setOpen] = React.useState(false);
@@ -119,4 +119,4 @@ import { Button } from "../button";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/multiselect/Multiselect.stories.mdx
+++ b/src/components/multiselect/Multiselect.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Select } from ".";
 import theme from "../../theme";
 
@@ -16,7 +16,7 @@ export type SelectProps = {
 
 ### Basic Select
 
-<Preview>
+<Canvas>
   <Story name="basic modal">
     {() => {
       const options = [
@@ -31,11 +31,11 @@ export type SelectProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Multiselect
 
-<Preview>
+<Canvas>
   <Story name="multiselect">
     {() => {
       const options = [
@@ -54,11 +54,11 @@ export type SelectProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Multiselect: colors
 
-<Preview>
+<Canvas>
   <Story name="colors">
     {() => {
       const options = [
@@ -95,4 +95,4 @@ export type SelectProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/navigation/Navigation.stories.mdx
+++ b/src/components/navigation/Navigation.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Navigation } from ".";
 import { Decos } from "./decos.tsx";
 import { SVGIcon } from "../svgicon";
@@ -28,7 +28,7 @@ import { Flex } from "../container";
 
 ### Primary Navigation
 
-<Preview>
+<Canvas>
   <Story name="primary">
     {() => {
       return (
@@ -46,11 +46,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Secondary Navigation
 
-<Preview>
+<Canvas>
   <Story name="secondary">
     {() => {
       return (
@@ -92,11 +92,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Business Context Navigation
 
-<Preview>
+<Canvas>
   <Story name="business context">
     {() => {
       return (
@@ -149,11 +149,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Popover Navigation
 
-<Preview>
+<Canvas>
   <Story name="popover">
     {() => {
       return (
@@ -174,11 +174,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Sidebar Navigation
 
-<Preview>
+<Canvas>
   <Story name="sidebar">
     {() => {
       return (
@@ -247,4 +247,4 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/pagetitle/PageTitle.stories.mdx
+++ b/src/components/pagetitle/PageTitle.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { PageTitle, PageTitleBreadcrumbs } from ".";
 
 <Meta title="Patterns/PageTitleBreadcrumbs" component={PageTitleBreadcrumbs} />
@@ -11,11 +11,11 @@ import { PageTitle, PageTitleBreadcrumbs } from ".";
 | ---------: | :------: | :----- | :---------- |
 |      title |   true   | string |             |
 
-<Preview>
+<Canvas>
   <Story name="pagetitle">
     <PageTitle title="Page Heading" />
   </Story>
-</Preview>
+</Canvas>
 
 # Page Title with Breadcrumbs
 
@@ -33,7 +33,7 @@ import { PageTitle, PageTitleBreadcrumbs } from ".";
 |      label |   true   | string |             |
 |        uri |   true   | string |             |
 
-<Preview>
+<Canvas>
   <Story name="breadcrumbs">
     <PageTitleBreadcrumbs
       title="Page Heading"
@@ -44,4 +44,4 @@ import { PageTitle, PageTitleBreadcrumbs } from ".";
       ]}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/pagination/Pagination.stories.mdx
+++ b/src/components/pagination/Pagination.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { PaginationBox } from ".";
 
 <Meta title="Components/Pagination" component={PaginationBox} />
@@ -19,15 +19,15 @@ import { PaginationBox } from ".";
 
 ## default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <PaginationBox count={400} from={0} size={20} setPage={0} setSize={20} />
   </Story>
-</Preview>
+</Canvas>
 
 ## small
 
-<Preview>
+<Canvas>
   <Story name="small">
     <PaginationBox
       small
@@ -38,4 +38,4 @@ import { PaginationBox } from ".";
       setSize={20}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/piechart/PieChart.stories.mdx
+++ b/src/components/piechart/PieChart.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Text } from "../text";
 import { Flex } from "../container";
 import { PieChart } from ".";
@@ -20,7 +20,7 @@ import { SVGIcon } from "../svgicon";
 
 ## Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <PieChart progress={33} size={96} strokeWidth={15}>
       <Text className="chartValue" size="lg" tag="span" weight="medium">
@@ -31,11 +31,11 @@ import { SVGIcon } from "../svgicon";
       </Text>
     </PieChart>
   </Story>
-</Preview>
+</Canvas>
 
 ## Stroke Width
 
-<Preview>
+<Canvas>
   <Story name="strokeWidth">
     <Flex justifyContent="space-evenly">
       <PieChart progress={33} size={96} strokeWidth={5}>
@@ -56,13 +56,13 @@ import { SVGIcon } from "../svgicon";
       </PieChart>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Color
 
 - You can change color using `color` props: `danger` | `warning` | `success` | `notification`;
 
-<Preview>
+<Canvas>
   <Story name="color">
     <Flex justifyContent="space-evenly">
       <PieChart progress={13} size={96} strokeWidth={15} color="danger">
@@ -105,4 +105,4 @@ import { SVGIcon } from "../svgicon";
       </PieChart>
     </Flex>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/popover/Popover.stories.mdx
+++ b/src/components/popover/Popover.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Popover } from ".";
 import { Button } from "../button";
 import { Spacer } from "../spacer";
@@ -18,7 +18,7 @@ import { Flex } from "../container";
 
 ## Default view
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Popover trigger={<Button severity="low" icon="menu" size="md" />}>
       <Button mb="0.25rem" severity="low" icon="plus" size="md">
@@ -30,11 +30,11 @@ import { Flex } from "../container";
     </Popover>
     <Spacer height="8rem" />
   </Story>
-</Preview>
+</Canvas>
 
 ## alignRight
 
-<Preview>
+<Canvas>
   <Story name="alignRight">
     <Flex justifyContent="flex-end">
       <Popover
@@ -51,4 +51,4 @@ import { Flex } from "../container";
     </Flex>
     <Spacer height="8rem" />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/radiobutton/Radiobutton.stories.mdx
+++ b/src/components/radiobutton/Radiobutton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Radio, RadioGroup } from ".";
 
 <Meta title="Forms/Radiobutton" component={Radio} />
@@ -13,11 +13,11 @@ import { Radio, RadioGroup } from ".";
 | ---------: | :------: | :----- | :------------------------- |
 |  labelText |   true   | string | label for the radio button |
 
-<Preview>
+<Canvas>
   <Story name="simple">
     <Radio id="radiobutton" labelText="GNUI Radio button" />
   </Story>
-</Preview>
+</Canvas>
 
 ## RadioGroup
 
@@ -29,7 +29,7 @@ import { Radio, RadioGroup } from ".";
 | ---------: | :------: | :----- | :---------- |
 |       name |   true   | string |             |
 
-<Preview>
+<Canvas>
   <Story name="group">
     <RadioGroup name="radiogroup">
       <Radio id="button1" labelText="New York" value="ny" />
@@ -37,4 +37,4 @@ import { Radio, RadioGroup } from ".";
       <Radio id="button3" labelText="Los Angeles" value="la" />
     </RadioGroup>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/selectbutton/SelectButton.stories.mdx
+++ b/src/components/selectbutton/SelectButton.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { MultipleSelect, SelectButton } from ".";
 import { Text } from "../text";
 
@@ -26,7 +26,7 @@ import { Text } from "../text";
 
 ### Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const [value, setValue] = React.useState();
@@ -57,13 +57,13 @@ import { Text } from "../text";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Small
 
 > - `size`: `string` — [`small`]
 
-<Preview>
+<Canvas>
   <Story name="small">
     {() => {
       const [value, setValue] = React.useState();
@@ -94,13 +94,13 @@ import { Text } from "../text";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Color Status
 
 > - `status`: `string` — [`success`, `danger`, `warning`, `notification`]
 
-<Preview>
+<Canvas>
   <Story name="status">
     {() => {
       const [value, setValue] = React.useState();
@@ -206,4 +206,4 @@ import { Text } from "../text";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/sidebar/Sidebar.stories.mdx
+++ b/src/components/sidebar/Sidebar.stories.mdx
@@ -1,7 +1,7 @@
 import {
   Meta,
   Story,
-  Preview,
+  Canvas,
   Title,
   Description,
 } from "@storybook/addon-docs/blocks";
@@ -32,7 +32,7 @@ import { PaginationBox } from "../pagination/Pagination.tsx";
 
 ### default
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const [isOpen, setIsOpen] = React.useState(false);
@@ -55,13 +55,13 @@ import { PaginationBox } from "../pagination/Pagination.tsx";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### footer
 
 You can pass Buttons to footer, and it will displayed at the bottom of the Sidebar.
 
-<Preview>
+<Canvas>
   <Story name="footer">
     {() => {
       const [isOpen, setIsOpen] = React.useState(false);
@@ -90,13 +90,13 @@ You can pass Buttons to footer, and it will displayed at the bottom of the Sideb
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### footer with pagination
 
 You can pass PaginationBox, and it will displayed at the bottom of the Sidebar.
 
-<Preview>
+<Canvas>
   <Story name="footer pagination">
     {() => {
       const [isOpen, setIsOpen] = React.useState(false);
@@ -129,13 +129,13 @@ You can pass PaginationBox, and it will displayed at the bottom of the Sidebar.
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### side
 
 Sidebar in default is displayed on the right side, but optionally you can change this behaviour with simple prop `side='onLeft'`.
 
-<Preview>
+<Canvas>
   <Story name="side">
     {() => {
       const [isOpen, setIsOpen] = React.useState(false);
@@ -176,13 +176,13 @@ Sidebar in default is displayed on the right side, but optionally you can change
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### width
 
 > If you don't need default breakpoints and needs just to hardcode `width` value you can provide it with `width` prop.
 
-<Preview>
+<Canvas>
   <Story name="custom width">
     {() => {
       const [isOpen20, setIsOpen20] = React.useState(false);
@@ -236,4 +236,4 @@ Sidebar in default is displayed on the right side, but optionally you can change
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/spacer/Spacer.stories.mdx
+++ b/src/components/spacer/Spacer.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Spacer } from ".";
 import { GnuiContainer, Flex } from "../container";
 import { Text } from "../text";
@@ -21,7 +21,7 @@ import theme from "../../theme";
 |     border |  false   | string         | border styles                          |
 |     margin |  false   | number, string |                                        |
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Flex>
       <GnuiContainer
@@ -47,9 +47,9 @@ import theme from "../../theme";
       </GnuiContainer>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="margin">
     <GnuiContainer>
       <GnuiContainer
@@ -77,4 +77,4 @@ import theme from "../../theme";
       </GnuiContainer>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/spinner/Spinner.stories.mdx
+++ b/src/components/spinner/Spinner.stories.mdx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Spinner } from ".";
 import { Spacer } from "../spacer";
 import { Flex } from "../container";
@@ -21,25 +21,25 @@ import theme from "../../theme";
 
 ## Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Spinner />
   </Story>
-</Preview>
+</Canvas>
 
 ## Ninja
 
-<Preview>
+<Canvas>
   <Story name="ninja">
     <Spinner ninja />
   </Story>
-</Preview>
+</Canvas>
 
 ## Color
 
 > `color`: `string` — **optional**: `success` | `danger` | `warning` | `notification` | `white`
 
-<Preview>
+<Canvas>
   <Story name="color">
     <Flex justifyContent="space-evenly">
       <Spinner color="success" />
@@ -48,13 +48,13 @@ import theme from "../../theme";
       <Spinner color="notification" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Size
 
 > `size`: `string` — **optional**: `sm` | `md` | `lg` | `xl` | `xxl`
 
-<Preview>
+<Canvas>
   <Story name="size">
     <Flex justifyContent="space-evenly">
       <Spinner size="sm" />
@@ -64,9 +64,9 @@ import theme from "../../theme";
       <Spinner size="xxl" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
-<Preview>
+<Canvas>
   <Story name="sizeNinja">
     <Flex justifyContent="space-evenly">
       <Spinner ninja size="sm" />
@@ -76,4 +76,4 @@ import theme from "../../theme";
       <Spinner ninja size="xxl" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/stickybar/StickyBar.stories.mdx
+++ b/src/components/stickybar/StickyBar.stories.mdx
@@ -2,7 +2,7 @@ import styled from "styled-components";
 import {
   Meta,
   Story,
-  Preview,
+  Canvas,
   Title,
   Description,
 } from "@storybook/addon-docs/blocks";
@@ -27,7 +27,7 @@ import theme from "../../theme";
 
 ## Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <div
       style={{
@@ -52,4 +52,4 @@ import theme from "../../theme";
       />
     </div>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/svgicon/SVGIcon.stories.mdx
+++ b/src/components/svgicon/SVGIcon.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { SVGIcon } from ".";
 import { Flex } from "../container";
 import CopyToClipboard from "react-copy-to-clipboard";
@@ -16,7 +16,7 @@ import { Text } from "../text";
 
 ### Icons Sizes
 
-<Preview>
+<Canvas>
   <Story name="size">
     <Flex justifyContent="space-evenly">
       <SVGIcon name="dashboard" size="sm" />
@@ -26,11 +26,11 @@ import { Text } from "../text";
       <SVGIcon name="dashboard" size="xxl" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Icons colors
 
-<Preview>
+<Canvas>
   <Story name="colors">
     <Flex justifyContent="space-evenly">
       <SVGIcon name="dashboard" />
@@ -40,13 +40,13 @@ import { Text } from "../text";
       <SVGIcon name="dashboard" color="notification" />
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Menu Icons
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="menu">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="dashboard">
@@ -81,13 +81,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Data
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="data">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="archive">
@@ -410,13 +410,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Operation
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="formatting">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="adjustments">
@@ -657,13 +657,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### User
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="user">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="contactPersons">
@@ -700,13 +700,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Navigation
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="navigation">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="arrowDown">
@@ -923,13 +923,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Operation
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="operation">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="production">
@@ -958,13 +958,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Status
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="status">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="statusError">
@@ -1009,13 +1009,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Cloud Provider
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="cloudProvider">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="aws">
@@ -1056,13 +1056,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### OS Provider
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="osProvider">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="linux">
@@ -1091,13 +1091,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### OS Components
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="osComponents">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="customCodeBuild">
@@ -1132,13 +1132,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### NC Icons
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="ncIcons">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="bulb">
@@ -1175,13 +1175,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Klarity Resource Type
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="klarityResources">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="externalIntegration">
@@ -1192,13 +1192,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### AWS Resource Type
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="awsResource">
     <Flex justifyContent="space-evenly">
       <CopyToClipboard text="ec2">
@@ -1311,13 +1311,13 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ### Deprecated Icons
 
 ###### Click on Icon to copy Icon Name to the clipboard
 
-<Preview>
+<Canvas>
   <Story name="ui">
     <Flex justifyContent="space-evenly" style={{ flexWrap: "wrap" }}>
       <CopyToClipboard text="networking">
@@ -1352,4 +1352,4 @@ import { Text } from "../text";
       </CopyToClipboard>
     </Flex>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/switch/Switch.stories.mdx
+++ b/src/components/switch/Switch.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Switch } from ".";
 import { GnuiContainer } from "../container";
 import { Spacer } from "../spacer";
@@ -20,15 +20,15 @@ import theme from "../../theme";
 
 ## default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Switch labelText="My Switch Button" />
   </Story>
-</Preview>
+</Canvas>
 
 ## position
 
-<Preview>
+<Canvas>
   <Story name="position">
     <GnuiContainer>
       <Switch name="label-left" position="left" labelText="My Switch Button" />
@@ -40,7 +40,7 @@ import theme from "../../theme";
       />
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ## severity
 
@@ -48,7 +48,7 @@ import theme from "../../theme";
 >
 > - `severity`: `string` — [`success`, `danger`, `warning`, `notification`]
 
-<Preview>
+<Canvas>
   <Story name="severity">
     {() => {
       const [toggle, setToggle] = React.useState(true);
@@ -89,4 +89,4 @@ import theme from "../../theme";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/table/Table.stories.mdx
+++ b/src/components/table/Table.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Table } from ".";
 import { Box } from "../box";
 import { Input } from "../input";
@@ -20,7 +20,7 @@ import { Flex } from "../container";
 
 ### Simple Table
 
-<Preview>
+<Canvas>
   <Story name="Simple">
     <Table>
       <Table.thead>
@@ -49,11 +49,11 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 ### Striped Table
 
-<Preview>
+<Canvas>
   <Story name="Striped">
     <Table striped>
       <Table.thead>
@@ -82,11 +82,11 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 ### Small Table
 
-<Preview>
+<Canvas>
   <Story name="Small">
     <Table small>
       <Table.thead>
@@ -115,11 +115,11 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 ### Small Table with small font (tiny)
 
-<Preview>
+<Canvas>
   <Story name="Small font (tiny)">
     <Table tiny>
       <Table.thead>
@@ -148,11 +148,11 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 ### Hoverline Table
 
-<Preview>
+<Canvas>
   <Story name="Hoverline">
     <Table hoverline>
       <Table.thead>
@@ -181,11 +181,11 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 ### Table with Header box and Pagination
 
-<Preview>
+<Canvas>
   <Story name="table-with-header">
     <Box boxStyle="lightGrey" innerSpacing="spacing03" spacing="spacing04">
       <Flex>
@@ -232,4 +232,4 @@ import { Flex } from "../container";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/tabs/Tabs.stories.mdx
+++ b/src/components/tabs/Tabs.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Tabs, Tab } from ".";
 import { Button } from "../button";
 import { Text } from "../text";
@@ -38,7 +38,7 @@ import { Flex } from "../container";
 
 ## Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -66,11 +66,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## No Caption
 
-<Preview>
+<Canvas>
   <Story name="nocaption">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -89,11 +89,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Custom Label
 
-<Preview>
+<Canvas>
   <Story name="Custom Label">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -121,7 +121,7 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Wizard With Buttons
 
@@ -131,7 +131,7 @@ import { Flex } from "../container";
 
 > `buttonsJustify?: string;` - Buttons justify, default: "space-between"
 
-<Preview>
+<Canvas>
   <Story name="With Buttons">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -185,13 +185,13 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Disabled tab
 
 > `disabled`: `boolean` — Disables switching to a tab by clicking on it
 
-<Preview>
+<Canvas>
   <Story name="disabled tab">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -233,11 +233,11 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ## Tab width
 
-<Preview>
+<Canvas>
   <Story name="width">
     {() => {
       const [currentStep, setCurrentStep] = React.useState(0);
@@ -261,4 +261,4 @@ import { Flex } from "../container";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/tag/Tag.stories.mdx
+++ b/src/components/tag/Tag.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Tag } from ".";
 import { Heading } from "../heading";
 import { Flex } from "../container";
@@ -16,7 +16,7 @@ import { Breadcrumbs } from "../breadcrumbs";
 - `showClose`: `boolean` — _optional_, show close button
 - `isTransparent`: `boolean` — _optional_, this prop makes the tag background transparent
 
-<Preview>
+<Canvas>
   <Story name="tag">
     <Tag text="Default tag" />
     <Tag
@@ -44,13 +44,13 @@ import { Breadcrumbs } from "../breadcrumbs";
       onClick={() => alert("clicked")}
     />
   </Story>
-</Preview>
+</Canvas>
 
 ## Colored Tag with close button
 
 > `color` props can be used in two ways: as an action colors build with `theme` (`accent`, `danger`, `success`, `warning`, `notification`, `primary`) or just in HEX/named color formats according to [X11 Colors](https://en.wikipedia.org/wiki/X11_color_names)
 
-<Preview>
+<Canvas>
   <Story name="close button">
     <Tag
       color="success"
@@ -77,13 +77,13 @@ import { Breadcrumbs } from "../breadcrumbs";
       onClick={() => alert("clicked")}
     />
   </Story>
-</Preview>
+</Canvas>
 
 ## Colored Tag with icons
 
 > By default, if you use custom colors text color will be `snowWhite` you can change text color using additional props `textColor`
 
-<Preview>
+<Canvas>
   <Story name="tag with icon">
     <Tag color="success" text="Success" icon="success" />
     <Tag color="warning" text="Warning" icon="info" />
@@ -92,4 +92,4 @@ import { Breadcrumbs } from "../breadcrumbs";
     <Tag text="Add" icon="plus" />
     <Tag text="Edit" icon="edit" />
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/text/Text.stories.mdx
+++ b/src/components/text/Text.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Text } from ".";
 import { GnuiContainer } from "../container";
 
@@ -24,17 +24,17 @@ import { GnuiContainer } from "../container";
 |     nowrap |  false   | boolean                                                                                               |                                                                                                                                                             |
 |    isTitle |  false   | boolean                                                                                               |                                                                                                                                                             |
 
-<Preview>
+<Canvas>
   <Story name="simple">
     <Text>Default paragraph.</Text>
   </Story>
-</Preview>
+</Canvas>
 
 ### size
 
 > `size`: `string` — ["xs" | "sm" | "md" | "lg" | "xl" | "xxl"]
 
-<Preview>
+<Canvas>
   <Story name="size">
     <GnuiContainer>
       <Text size="xs">(xs) Extra Small size (10px)</Text>
@@ -45,13 +45,13 @@ import { GnuiContainer } from "../container";
       <Text size="xxl">(xxl) Extra Large size (32px)</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### tag
 
 > `tag`: `string` — `Text` can can be rendered as any other HTML tag instead of `p` (i.e. can be rendered as a `span`). Check this in your dev-tools (<kbd>CTRL</kbd> + <kbd>C</kbd> in Chrome). Uses `as` prop from `styled-components` under the hood.
 
-<Preview>
+<Canvas>
   <Story name="tag">
     <GnuiContainer>
       <Text tag="div">
@@ -59,13 +59,13 @@ import { GnuiContainer } from "../container";
       </Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### weight
 
 > `weight`: `string` - ["regular" | "medium" | "bold"]
 
-<Preview>
+<Canvas>
   <Story name="weight">
     <GnuiContainer>
       <Text weight="regular">Lorem ipsum solor domet.</Text>
@@ -73,13 +73,13 @@ import { GnuiContainer } from "../container";
       <Text weight="bold">Lorem ipsum solor domet.</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### color
 
 > `color`: `string` - GNUI as first looks for the value in `theme.colors` and if color doesn't exist there `color` will be used as is.
 
-<Preview>
+<Canvas>
   <Story name="color">
     <GnuiContainer>
       <Text color="danger">Lorem ipsum solor domet.</Text>
@@ -89,26 +89,26 @@ import { GnuiContainer } from "../container";
       <Text color="#ccc">Lorem ipsum solor domet.</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### textStyle
 
 > `textStyle`: `string` - ["normal" | "italic"]
 
-<Preview>
+<Canvas>
   <Story name="textStyle">
     <GnuiContainer>
       <Text textStyle="normal">Lorem ipsum solor domet.</Text>
       <Text textStyle="italic">Lorem ipsum solor domet.</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### align
 
 > `align`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="align">
     <GnuiContainer>
       <Text align="left">Lorem ipsum solor domet.</Text>
@@ -116,16 +116,16 @@ import { GnuiContainer } from "../container";
       <Text align="right">Lorem ipsum solor domet.</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>
 
 ### isTitle
 
 > `isTitle`: `boolean`
 
-<Preview>
+<Canvas>
   <Story name="isTitle">
     <GnuiContainer>
       <Text isTitle="true">Lorem ipsum solor domet.</Text>
     </GnuiContainer>
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/textarea/Textarea.stories.mdx
+++ b/src/components/textarea/Textarea.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Textarea } from ".";
 import { GnuiContainer } from "../container";
 import { Spacer } from "../spacer";
@@ -18,25 +18,25 @@ import theme from "../../theme";
 
 ## default
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Textarea />
   </Story>
-</Preview>
+</Canvas>
 
 ## small
 
-<Preview>
+<Canvas>
   <Story name="small">
     <Textarea small />
   </Story>
-</Preview>
+</Canvas>
 
 ## status
 
 > `status`: `success | error`
 
-<Preview>
+<Canvas>
   <Story name="status">
     {() => {
       const [status, setStatus] = React.useState("success");
@@ -61,4 +61,4 @@ import theme from "../../theme";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/toggle/Toggle.stories.mdx
+++ b/src/components/toggle/Toggle.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Toggle } from ".";
 import { Spacer } from "../spacer";
 
@@ -19,7 +19,7 @@ import { Spacer } from "../spacer";
 
 ### Default
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const [toggle, setToggle] = React.useState(false);
@@ -32,13 +32,13 @@ import { Spacer } from "../spacer";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Small
 
 > - `size`: `small`
 
-<Preview>
+<Canvas>
   <Story name="small">
     {() => {
       const [toggle, setToggle] = React.useState(false);
@@ -53,13 +53,13 @@ import { Spacer } from "../spacer";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 ### Color Status
 
 > - `status`: `success`, `danger`, `warning`, `notification`
 
-<Preview>
+<Canvas>
   <Story name="status">
     {() => {
       const [toggle, setToggle] = React.useState(false);
@@ -108,4 +108,4 @@ import { Spacer } from "../spacer";
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/components/tooltip/Tooltip.stories.mdx
+++ b/src/components/tooltip/Tooltip.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Tooltip } from ".";
 import { Text } from "../text";
 import {  Flex } from "../container";
@@ -21,7 +21,7 @@ import { Input } from "../input";
 
 > `caption: string;` - caption for the tooltip
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Flex
       justifyContent="space-evenly"
@@ -32,13 +32,13 @@ import { Input } from "../input";
       </Tooltip>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Bottom Tooltip
 
 > `bottom: boolean;` - positioning tooltip at the bottom
 
-<Preview>
+<Canvas>
   <Story name="bottom">
     <Flex
       justifyContent="space-evenly"
@@ -49,13 +49,13 @@ import { Input } from "../input";
       </Tooltip>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Tooltip Position
 
 > - `position`: `left` | `right` - you can align the tooltip to the right side or to the left side of your child element
 
-<Preview>
+<Canvas>
   <Story name="position">
     <Flex
       justifyContent="space-evenly"
@@ -79,13 +79,13 @@ import { Input } from "../input";
       </div>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Tooltip Status
 
 > - `status`: `danger` | `warning` | `success` | `notification`
 
-<Preview>
+<Canvas>
   <Story name="status">
     <Flex
       justifyContent="space-evenly"
@@ -113,11 +113,11 @@ import { Input } from "../input";
       </div>
     </Flex>
   </Story>
-</Preview>
+</Canvas>
 
 ## Tooltip with other Components
 
-<Preview>
+<Canvas>
   <Story name="components">
     <Flex
       justifyContent="space-evenly"
@@ -146,4 +146,4 @@ import { Input } from "../input";
       </div>
     </Flex>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/Applications.stories.mdx
+++ b/src/stories/Applications.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Col, Row, Hidden } from "react-awesome-styled-grid";
 import theme from "../theme";
 import { Flex } from "../components/container";
@@ -15,7 +15,7 @@ import { Navigation } from "../components/navigation";
 
 <Meta title="Pages/Applications" />
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Box spacing={"spacing04"} style={{ maxWidth: "1440px" }}>
       <Box
@@ -405,4 +405,4 @@ import { Navigation } from "../components/navigation";
       </Row>
     </Box>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/Dashboard.stories.mdx
+++ b/src/stories/Dashboard.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Col, Row, Visible } from "react-awesome-styled-grid";
 import theme from "../theme";
 import { Flex } from "../components/container";
@@ -9,7 +9,7 @@ import { Spacer } from "../components/spacer";
 
 <Meta title="Pages/Dashboard" />
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Box style={{maxWidth: "1440px"}}>
       <Row>
@@ -90,4 +90,4 @@ import { Spacer } from "../components/spacer";
       </Row>
     </Box>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/GnuiColors.stories.mdx
+++ b/src/stories/GnuiColors.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Table } from "../components/table";
 import { Box } from "../components/box";
 import { Col, Row } from "react-awesome-styled-grid";
@@ -9,7 +9,7 @@ import { Text } from "../components";
 
 # Backgrounds
 
-<Preview>
+<Canvas>
   <Story name="Backgrounds">
     <Text weight="medium">Default page background</Text>
     <Table>
@@ -320,11 +320,11 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 # Text colors
 
-<Preview>
+<Canvas>
   <Story name="Text colors">
     <Text weight="medium">Text copy colors</Text>
     <Table>
@@ -574,11 +574,11 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 # Field colors
 
-<Preview>
+<Canvas>
   <Story name="Field backgrounds">
     <Text weight="medium">Fields background colors</Text>
     <Table>
@@ -647,11 +647,11 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 # Border colors
 
-<Preview>
+<Canvas>
   <Story name="Border colors">
     <Text weight="medium">Border colors</Text>
     <Table>
@@ -814,11 +814,11 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 # Interactive colors
 
-<Preview>
+<Canvas>
   <Story name="Interactive colors">
     <Text weight="medium">Primary interactive (primary buttons)</Text>
     <Table>
@@ -1399,11 +1399,11 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>
 
 # Support colors
 
-<Preview>
+<Canvas>
   <Story name="Support colors">
     <Text weight="medium">Colors for using on charts with some status</Text>
     <Table>
@@ -1889,4 +1889,4 @@ import { Text } from "../components";
       </Table.tbody>
     </Table>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/Grid.stories.mdx
+++ b/src/stories/Grid.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Container, Row, Col } from "react-awesome-styled-grid";
 import { Text } from "../components/text";
 import theme from "../theme";
@@ -7,7 +7,7 @@ import theme from "../theme";
 
 ## Basic usage
 
-<Preview>
+<Canvas>
   <Story name="justifyContent">
     {() => {
       return (
@@ -24,7 +24,7 @@ import theme from "../theme";
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 We use [React Awesome Styled Grid](https://awesome-styled-grid.netlify.app/usage)
 

--- a/src/stories/TotalSpend.stories.mdx
+++ b/src/stories/TotalSpend.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Text } from "../components/text";
 import { Flex } from "../components/container";
 import theme from "../theme";
@@ -9,7 +9,7 @@ import { PieChart } from "../components/piechart";
 
 # Total spend Widget
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Flex>
       <div>
@@ -43,4 +43,4 @@ import { PieChart } from "../components/piechart";
       </Box>
     </Flex>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/Wizard.stories.mdx
+++ b/src/stories/Wizard.stories.mdx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Tabs, Tab, ButtonPrevious, ButtonNext } from "../components/tabs";
 import { Text } from "../components/text";
 import { Button } from "../components/button";
@@ -43,7 +43,7 @@ type TabsProps = {
 > `nextButton?: string;` - label for Next button
 > `submitButton?: string;` - label for Submit button
 
-<Preview>
+<Canvas>
   <Story name="default">
     {() => {
       const [isCurrentStep, setCurrentStep] = React.useState(0);
@@ -140,11 +140,11 @@ type TabsProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>
 
 > `disabled?: boolean;` - makes the step non-clickable
 
-<Preview>
+<Canvas>
   <Story name="disabled">
     {() => {
       const [isCurrentStep, setCurrentStep] = React.useState(0);
@@ -240,4 +240,4 @@ type TabsProps = {
       );
     }}
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/appDetails.stories.mdx
+++ b/src/stories/appDetails.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Col, Row, Hidden } from "react-awesome-styled-grid";
 import theme from "../theme";
 import { Flex } from "../components/container";
@@ -14,7 +14,7 @@ import { Navigation } from "../components/navigation";
 
 <Meta title="Pages/appDetails" />
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Box spacing={"spacing04"} style={{ maxWidth: "1440px" }}>
       <Box
@@ -337,4 +337,4 @@ import { Navigation } from "../components/navigation";
       </Box>
     </Box>
   </Story>
-</Preview>
+</Canvas>

--- a/src/stories/ouDetails.stories.mdx
+++ b/src/stories/ouDetails.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, Preview } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks";
 import { Col, Row } from "react-awesome-styled-grid";
 import theme from "../theme";
 import { Flex } from "../components/container";
@@ -10,7 +10,7 @@ import { Spacer } from "../components/spacer";
 
 <Meta title="Pages/OU Details" />
 
-<Preview>
+<Canvas>
   <Story name="default">
     <Box spacing={"spacing02"} style={{ maxWidth: "1440px" }}>
       <Text weight="medium">Environments attached to Organization Unit</Text>
@@ -110,4 +110,4 @@ import { Spacer } from "../components/spacer";
       </Box>
     </Box>
   </Story>
-</Preview>
+</Canvas>


### PR DESCRIPTION
# What

This PR closes #402 opened earlier. Let me know if I should change anything to it.

- What was done in this Pull Request
  - Replaced deprecated Preview blocks with Canvas as per [v6.0.0](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#previewprops-renamed)
  - Fixed missing `"` from DOCS_GUIDE [documentation](https://github.com/nordcloud/GNUI/blob/master/DOCS_GUIDE.md#default-component) code block.
- How was it before
  - Preview blocks which asserts deprecation warnings in the console

## Testing

- [x] Is this change covered by the unit tests?

- [x] Is this change covered by the integration tests?

- [x] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?
