### PR TITLE
showRoots original location location in options changed

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,7 +7,9 @@ import "./global.css";
 
 addParameters({
   options: {
-    showRoots: true,
+    sidebar: {
+      showRoots: true,
+    },
     storySort: {
       order: [
         "Foundation",


### PR DESCRIPTION
# What

The showRoots option is deprecated and set to change in v7 for StoryBook. This closes #404.

- What was done in this Pull Request
  - Change the location of showRoots to be under sidebar options as mentioned [here](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-showroots-config-option)
- How was it before
  - Option side at top-level, which will be incompatible with the next major release of Storybook (v7).

## Testing

- [x] Is this change covered by the unit tests?

- [x] Is this change covered by the integration tests?

- [x] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?
