### PR TITLE
Add readOnly attribute to input field with value in Storybook

### DIFF
--- a/src/components/input/Input.stories.mdx
+++ b/src/components/input/Input.stories.mdx
@@ -142,6 +142,7 @@ Placeholder text inside input element
             <Input
               name="validation-input"
               value={status === "success" ? "Success!" : "Error!"}
+              readOnly
               status={status}
             />
           </GnuiContainer>


### PR DESCRIPTION
# What

Closes #406

- What was done in this Pull Request
  - Add readOnly attribute for Storybook Input example with value (Success|Error), since React is giving an error about assuming field mutability instead of it being explicit.
- How was it before
  - Without readyOnly attribute it was giving an error and anyone copying the code example would have had an error thrown in console.

## Testing

- [x] Is this change covered by the unit tests?

- [x] Is this change covered by the integration tests?

- [x] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?
