### PR TITLE
Add readOnly attribute to switch field with value in Storybook

### DIFF
--- a/src/components/switch/Switch.stories.mdx
+++ b/src/components/switch/Switch.stories.mdx
@@ -60,6 +60,7 @@ import theme from "../../theme";
             labelText="My Switch Button Warning"
             onClick={() => setToggle((prevState) => !prevState)}
             checked={toggle}
+            readOnly
           />
           <Spacer height="1rem" />
           <Switch
@@ -68,6 +69,7 @@ import theme from "../../theme";
             labelText="My Switch Button Danger"
             onClick={() => setToggle((prevState) => !prevState)}
             checked={toggle}
+            readOnly
           />
           <Spacer height="1rem" />
           <Switch
@@ -76,6 +78,7 @@ import theme from "../../theme";
             labelText="My Switch Button Success"
             onClick={() => setToggle((prevState) => !prevState)}
             checked={toggle}
+            readOnly
           />
           <Spacer height="1rem" />
           <Switch
@@ -84,6 +87,7 @@ import theme from "../../theme";
             labelText="My Switch Button Notification"
             onClick={() => setToggle((prevState) => !prevState)}
             checked={toggle}
+            readOnly
           />
         </GnuiContainer>
       );


### PR DESCRIPTION
# What

Closes #408 

- What was done in this Pull Request
  - Add readOnly attribute for Storybook's Switch last example, since React is giving an error about assuming field mutability instead of it being explicit. I added readOnly to keep the same behavior, although the example could be simpler if we removed the stateful onClick event, but I understand it could be of use to react starters.
- How was it before
  - Without readyOnly attribute it was giving an error and anyone copying the code example would have had an error thrown in console.

## Testing

- [x] Is this change covered by the unit tests?

- [x] Is this change covered by the integration tests?

- [x] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?
