### PR TITLE
fix useClickOutside when clicking on icons

### DIFF
--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -18,7 +18,7 @@ export const useClickOutside = <E extends Event = Event>(
     if (active) {
       const handler = (event: E) => {
         const { current: el } = ref;
-        if (el instanceof HTMLElement && event.target instanceof HTMLElement) {
+        if (el instanceof Element && event.target instanceof Element) {
           !el.contains(event.target) && savedCallback.current(event);
         }
       };


### PR DESCRIPTION
# What

- What was done in this Pull Request

Change the `instance HTMLElement` to `instance Element` in `useClickOutside` to satisfy the condition for icons, which are `SVGElements` and are not an instance of `HTMLElement`

- How was it before

Condition was satisfied only for elements that were instances of HTMLElement

- Screenshots

See `After` section

- Any other information that may be useful for the dev to review Pull Request

There may be a case that `Element` is too broad compared to `HTMLElement` which was there in the first place. Couldn't came up with any idea why it was done that way initially and if I'm not breaking anything 🤔 
On the other hand I started wondering if the `implements ...` checks are needed there.

## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

https://user-images.githubusercontent.com/20808724/148845996-ff5f3bba-ae16-4ccd-af2f-82dc2e6a9662.mov

### After

https://user-images.githubusercontent.com/20808724/148846014-1eca9222-d873-46be-a1f1-946fee1197ed.mov