### PR TITLE
Fix tabs border styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -74,6 +74,7 @@ export const TabContainer = styled.div<{
     background-color: ${theme.color.background.ui01};
     border-bottom: 1px solid ${theme.color.background.ui01};
     z-index: ${theme.zindex.default};
+    position: relative;
 
     &::before {
       content: "";

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -74,7 +74,6 @@ export const TabContainer = styled.div<{
     background-color: ${theme.color.background.ui01};
     border-bottom: 1px solid ${theme.color.background.ui01};
     z-index: ${theme.zindex.default};
-    position: relative;
 
     &::before {
       content: "";

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -74,8 +74,17 @@ export const TabContainer = styled.div<{
     background-color: ${theme.color.background.ui01};
     border-bottom: 1px solid ${theme.color.background.ui01};
     z-index: ${theme.zindex.default};
-    border-top: 4px solid ${theme.color.interactive.primary};
-    margin-top: -4px;
+    position: relative;
+
+    &::before {
+      content: "";
+      width: 100%;
+      height: 4px;
+      position: absolute;
+      left: 0;
+      top: 0;
+      background-color: ${theme.color.interactive.primary};
+    }
   }
 
   &.tab,
@@ -95,9 +104,20 @@ const TabsList = styled.div`
   padding: 0;
   margin: 0;
   position: relative;
-  border-top: 4px solid ${theme.color.border.input};
+  overflow-x: auto;
   border-top-left-radius: ${theme.radiusDefault};
   border-top-right-radius: ${theme.radiusDefault};
+  margin-top: 4px;
+
+  &::before {
+    content: "";
+    width: 100%;
+    height: 4px;
+    position: absolute;
+    left: 0;
+    top: 0;
+    background-color: ${theme.color.border.input};
+  }
 
   &::after {
     content: "";

--- a/src/components/tabs/Tabs.tsx
+++ b/src/components/tabs/Tabs.tsx
@@ -82,7 +82,7 @@ export const TabContainer = styled.div<{
       height: 4px;
       position: absolute;
       left: 0;
-      top: 0;
+      top: -4px;
       background-color: ${theme.color.interactive.primary};
     }
   }
@@ -107,7 +107,7 @@ const TabsList = styled.div`
   overflow-x: auto;
   border-top-left-radius: ${theme.radiusDefault};
   border-top-right-radius: ${theme.radiusDefault};
-  margin-top: 4px;
+  padding-top: 4px;
 
   &::before {
     content: "";
@@ -115,7 +115,7 @@ const TabsList = styled.div`
     height: 4px;
     position: absolute;
     left: 0;
-    top: 0;
+    top: -4px;
     background-color: ${theme.color.border.input};
   }
 


### PR DESCRIPTION
# What

- Fixed tabs top borders styling by changing them into before pseudoelements

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/74356801/161557352-feacb87b-9c61-46d1-8b36-80ad57453091.png)

### After
![image](https://user-images.githubusercontent.com/74356801/161557380-3b08cd4d-bf2b-495f-a8e7-8b91b236995f.png)
