### PR TITLE
Allow button to take arbitrary component to be rendered and properly type its props

### DIFF
--- a/src/components/button/Button.stories.mdx
+++ b/src/components/button/Button.stories.mdx
@@ -22,6 +22,7 @@ import { GnuiContainer, Flex } from "../container";
 |     disabled |  false   | boolean                                                        |                                                                                                                                                                                                                                        |
 |       linkTo |  false   | string                                                         | displays button as a link                                                                                                                                                                                                              |
 |      display |  false   | <code>flex</code>, <code>inline-flex</code>                    | you might want to change the display value when using linkTo prop                                                                                                                                                                      |
+|           as |  false   | React.ElementType                                              | any valid HTML element or React component                                                                                                                                                                                              |
 
 ## default button
 
@@ -179,6 +180,18 @@ import { GnuiContainer, Flex } from "../container";
       target="_blank"
     >
       Button
+    </Button>
+  </Story>
+</Canvas>
+
+## as
+
+> as: `React.ElementType`
+
+<Canvas>
+  <Story name="as">
+    <Button as="a" href="http://google.com" target="_blank">
+      Link to
     </Button>
   </Story>
 </Canvas>

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -119,7 +119,7 @@ const StyledButton = styled.button<ButtonProps<React.ElementType>>`
   text-decoration: none;
   display: ${({ display, linkTo }) =>
     !display && linkTo ? "inline-flex" : display || "flex"};
-  flex-direction: ${(props: ButtonProps<React.ElementType>) =>
+  flex-direction: ${(props: ButtonProps) =>
     props.iconRight ? "row-reverse" : "row"};
   align-items: center;
   text-transform: ${theme.typography.titleCase};
@@ -198,9 +198,9 @@ const StyledButton = styled.button<ButtonProps<React.ElementType>>`
   ${({ color }) =>
     color &&
     css`
-      background-color: ${(props: ButtonProps<React.ElementType>) =>
+      background-color: ${(props: ButtonProps) =>
         props.severity === "medium" ? "transparent" : setColor(color)};
-      color: ${(props: ButtonProps<React.ElementType>) =>
+      color: ${(props: ButtonProps) =>
         props.severity === "medium"
           ? setColor(color)
           : theme.color.text.text04};
@@ -213,7 +213,7 @@ const StyledButton = styled.button<ButtonProps<React.ElementType>>`
       }
       .spinner {
         div {
-          border-color: ${(props: ButtonProps<React.ElementType>) =>
+          border-color: ${(props: ButtonProps) =>
               props.severity === "medium"
                 ? setColor(color)
                 : theme.color.text.text04}
@@ -221,17 +221,17 @@ const StyledButton = styled.button<ButtonProps<React.ElementType>>`
         }
       }
       &:hover {
-        color: ${(props: ButtonProps<React.ElementType>) =>
+        color: ${(props: ButtonProps) =>
           props.severity === "medium"
             ? setColor(color)
             : theme.color.text.text04};
-        background-color: ${(props: ButtonProps<React.ElementType>) =>
+        background-color: ${(props: ButtonProps) =>
           props.severity === "medium"
             ? lighten(0.35, setColor(color))
             : darken(0.1, setColor(color))};
       }
       &:active {
-        background: ${(props: ButtonProps<React.ElementType>) =>
+        background: ${(props: ButtonProps) =>
           props.severity === "medium"
             ? lighten(0.25, setColor(color))
             : darken(0.2, setColor(color))};

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,24 +8,25 @@ import { setColor } from "../../utils/setcolor";
 import { Spinner } from "../spinner";
 import { SVGIcon, SVGIconProps } from "../svgicon";
 
-export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  children?: string | React.ReactNode;
-  severity?: "high" | "medium" | "low";
-  size?: "sm" | "md";
-  icon?: SVGIconProps["name"];
-  iconRight?: boolean;
-  initialState?: string;
-  color?: SingleColors;
-  form?: string;
-  select?: boolean;
-  className?: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-  as?: React.ElementType | "a" | "button";
-  linkTo?: string;
-  display?: "flex" | "inline-flex";
-  outline?: boolean;
-  secondary?: boolean;
-};
+export type ButtonProps<T extends React.ElementType> =
+  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children?: string | React.ReactNode;
+    severity?: "high" | "medium" | "low";
+    size?: "sm" | "md";
+    icon?: SVGIconProps["name"];
+    iconRight?: boolean;
+    initialState?: string;
+    color?: SingleColors;
+    form?: string;
+    select?: boolean;
+    className?: string;
+    onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+    as?: T | "a" | "button";
+    linkTo?: string;
+    display?: "flex" | "inline-flex";
+    outline?: boolean;
+    secondary?: boolean;
+  } & React.ComponentProps<T>;
 
 const changeSize = (size: string) => {
   switch (size) {
@@ -104,7 +105,7 @@ const changeSeverity = (severity: string) => {
 };
 
 /* eslint-disable sonarjs/no-identical-functions */
-const StyledButton = styled.button<ButtonProps>`
+const StyledButton = styled.button<ButtonProps<React.ElementType>>`
   background: ${theme.color.interactive.primary};
   white-space: nowrap;
   font-family: ${theme.fonts.body};
@@ -118,7 +119,7 @@ const StyledButton = styled.button<ButtonProps>`
   text-decoration: none;
   display: ${({ display, linkTo }) =>
     !display && linkTo ? "inline-flex" : display || "flex"};
-  flex-direction: ${(props: ButtonProps) =>
+  flex-direction: ${(props: ButtonProps<React.ElementType>) =>
     props.iconRight ? "row-reverse" : "row"};
   align-items: center;
   text-transform: ${theme.typography.titleCase};
@@ -197,9 +198,9 @@ const StyledButton = styled.button<ButtonProps>`
   ${({ color }) =>
     color &&
     css`
-      background-color: ${(props: ButtonProps) =>
+      background-color: ${(props: ButtonProps<React.ElementType>) =>
         props.severity === "medium" ? "transparent" : setColor(color)};
-      color: ${(props: ButtonProps) =>
+      color: ${(props: ButtonProps<React.ElementType>) =>
         props.severity === "medium"
           ? setColor(color)
           : theme.color.text.text04};
@@ -212,7 +213,7 @@ const StyledButton = styled.button<ButtonProps>`
       }
       .spinner {
         div {
-          border-color: ${(props: ButtonProps) =>
+          border-color: ${(props: ButtonProps<React.ElementType>) =>
               props.severity === "medium"
                 ? setColor(color)
                 : theme.color.text.text04}
@@ -220,17 +221,17 @@ const StyledButton = styled.button<ButtonProps>`
         }
       }
       &:hover {
-        color: ${(props: ButtonProps) =>
+        color: ${(props: ButtonProps<React.ElementType>) =>
           props.severity === "medium"
             ? setColor(color)
             : theme.color.text.text04};
-        background-color: ${(props: ButtonProps) =>
+        background-color: ${(props: ButtonProps<React.ElementType>) =>
           props.severity === "medium"
             ? lighten(0.35, setColor(color))
             : darken(0.1, setColor(color))};
       }
       &:active {
-        background: ${(props: ButtonProps) =>
+        background: ${(props: ButtonProps<React.ElementType>) =>
           props.severity === "medium"
             ? lighten(0.25, setColor(color))
             : darken(0.2, setColor(color))};
@@ -239,14 +240,14 @@ const StyledButton = styled.button<ButtonProps>`
   ${space}
 `;
 
-export function Button({
+export function Button<T extends React.ElementType>({
   children,
   icon,
   initialState,
   linkTo,
   display,
   ...props
-}: ButtonProps & SpaceProps) {
+}: ButtonProps<T> & SpaceProps) {
   switch (initialState) {
     case "success":
       return (

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,25 +8,24 @@ import { setColor } from "../../utils/setcolor";
 import { Spinner } from "../spinner";
 import { SVGIcon, SVGIconProps } from "../svgicon";
 
-export type ButtonProps<T extends React.ElementType = "button"> =
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
-    children?: string | React.ReactNode;
-    severity?: "high" | "medium" | "low";
-    size?: "sm" | "md";
-    icon?: SVGIconProps["name"];
-    iconRight?: boolean;
-    initialState?: string;
-    color?: SingleColors;
-    form?: string;
-    select?: boolean;
-    className?: string;
-    onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-    as?: T;
-    linkTo?: string;
-    display?: "flex" | "inline-flex";
-    outline?: boolean;
-    secondary?: boolean;
-  } & React.ComponentProps<T>;
+export type ButtonProps<T extends React.ElementType = "button"> = {
+  children?: string | React.ReactNode;
+  severity?: "high" | "medium" | "low";
+  size?: "sm" | "md";
+  icon?: SVGIconProps["name"];
+  iconRight?: boolean;
+  initialState?: string;
+  color?: SingleColors;
+  form?: string;
+  select?: boolean;
+  className?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  as?: T;
+  linkTo?: string;
+  display?: "flex" | "inline-flex";
+  outline?: boolean;
+  secondary?: boolean;
+} & React.ComponentProps<T>;
 
 const changeSize = (size: string) => {
   switch (size) {

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -245,13 +245,11 @@ export function Button<T extends React.ElementType = "button">({
   icon,
   initialState,
   linkTo,
-  display,
   ...props
 }: ButtonProps<T> & SpaceProps) {
   return (
     <StyledButton
       as={linkTo ? "a" : "button"}
-      display={display}
       href={linkTo}
       linkTo={linkTo}
       {...props}

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -8,7 +8,7 @@ import { setColor } from "../../utils/setcolor";
 import { Spinner } from "../spinner";
 import { SVGIcon, SVGIconProps } from "../svgicon";
 
-export type ButtonProps<T extends React.ElementType> =
+export type ButtonProps<T extends React.ElementType = "button"> =
   React.ButtonHTMLAttributes<HTMLButtonElement> & {
     children?: string | React.ReactNode;
     severity?: "high" | "medium" | "low";
@@ -21,7 +21,7 @@ export type ButtonProps<T extends React.ElementType> =
     select?: boolean;
     className?: string;
     onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-    as?: T | "a" | "button";
+    as?: T;
     linkTo?: string;
     display?: "flex" | "inline-flex";
     outline?: boolean;
@@ -240,7 +240,7 @@ const StyledButton = styled.button<ButtonProps<React.ElementType>>`
   ${space}
 `;
 
-export function Button<T extends React.ElementType>({
+export function Button<T extends React.ElementType = "button">({
   children,
   icon,
   initialState,

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -248,78 +248,35 @@ export function Button<T extends React.ElementType = "button">({
   display,
   ...props
 }: ButtonProps<T> & SpaceProps) {
+  return (
+    <StyledButton
+      as={linkTo ? "a" : "button"}
+      display={display}
+      href={linkTo}
+      linkTo={linkTo}
+      {...props}
+    >
+      <ButtonIcon {...{ initialState, icon }} />
+      {children && <span>{children}</span>}
+    </StyledButton>
+  );
+}
+
+type ButtonIconProps = Pick<ButtonProps, "initialState" | "icon">;
+
+function ButtonIcon({ initialState, icon }: ButtonIconProps) {
   switch (initialState) {
     case "success":
-      return (
-        <StyledButton
-          as={linkTo ? "a" : "button"}
-          display={display}
-          href={linkTo}
-          linkTo={linkTo}
-          {...props}
-        >
-          <SVGIcon name="success" />
-          {children && <span>{children}</span>}
-        </StyledButton>
-      );
+      return <SVGIcon name="success" />;
     case "error":
-      return (
-        <>
-          <StyledButton
-            as={linkTo ? "a" : "button"}
-            display={display}
-            href={linkTo}
-            linkTo={linkTo}
-            {...props}
-          >
-            <SVGIcon name="danger" />
-            {children && <span>{children}</span>}
-          </StyledButton>
-        </>
-      );
+      return <SVGIcon name="danger" />;
     case "loading":
       return (
-        <>
-          <StyledButton
-            as={linkTo ? "a" : "button"}
-            display={display}
-            href={linkTo}
-            linkTo={linkTo}
-            {...props}
-          >
-            <div className="spinner">
-              <Spinner size="sm" />
-            </div>
-            {children && <span>{children}</span>}
-          </StyledButton>
-        </>
+        <div className="spinner">
+          <Spinner size="sm" />
+        </div>
       );
     default:
-      return (
-        <>
-          {icon ? (
-            <StyledButton
-              as={linkTo ? "a" : "button"}
-              display={display}
-              href={linkTo}
-              linkTo={linkTo}
-              {...props}
-            >
-              <SVGIcon name={icon} />
-              {children && <span>{children}</span>}
-            </StyledButton>
-          ) : (
-            <StyledButton
-              as={linkTo ? "a" : "button"}
-              display={display}
-              linkTo={linkTo}
-              href={linkTo}
-              {...props}
-            >
-              <span>{children}</span>
-            </StyledButton>
-          )}
-        </>
-      );
+      return icon ? <SVGIcon name={icon} /> : null;
   }
 }


### PR DESCRIPTION
# What

## What was done in this Pull Request

Adjusting types to allow `Button` component to pass any component in `as` prop and properly type its props

## Screenshots

![Screenshot 2022-05-25 at 08 06 27](https://user-images.githubusercontent.com/20808724/170193503-13a8cec6-b909-4363-a28d-174650f2529e.png)

## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [ ] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
