### PR TITLE
[KLAR-5919] Sidebar padding customisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "5.9.6",
+      "version": "5.9.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "5.9.6",
+  "version": "5.9.7",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/sidebar/Sidebar.stories.mdx
+++ b/src/components/sidebar/Sidebar.stories.mdx
@@ -13,18 +13,18 @@ import { PaginationBox } from "../pagination/Pagination.tsx";
 
 ## Sidebar properties
 
-| properties         | required | type                                                                                                            | description |
-| ----------------:  | :------: | :-------------------------------------------------------------------------------------------------------------- | :---------- |
-|   children         |  false   | <code>`ReactElement<any>`</code>                                                                                |             |
-|      title         |  false   | string                                                                                                          |             |
-|    caption         |  false   | string                                                                                                          |             |
-|     isOpen         |  false   | boolean                                                                                                         |             |
-|       side         |  false   | <code>onLeft</code>, <code>onRight</code>                                                                       |             |
-|      width         |  false   | number, string                                                                                                  |             |
-|    onClick         |  false   | <code>(e: any) => void</code>                                                                                   |             |
-|     footer         |  false   | <code>`ReactElement<any>`</code>                                                                                |             |
-|     headerProps    |  false   | <code>`{reverse?: boolean, padding?: {top?: string, right?: string, bottom?: string, left?: string}}`</code>    |             |
-|     containerProps |  false   | <code>`{padding?: {top?: string, right?: string, bottom?: string, left?: string}}`</code>                       |             |
+| properties         | required | type                                                      | description |
+| -----------------: | :------: | :-------------------------------------------------------- | :---------- |
+|   children         |  false   | <code>`ReactElement<any>`</code>                          |             |
+|      title         |  false   | string                                                    |             |
+|    caption         |  false   | string                                                    |             |
+|     isOpen         |  false   | boolean                                                   |             |
+|       side         |  false   | <code>onLeft</code>, <code>onRight</code>                 |             |
+|      width         |  false   | number, string                                            |             |
+|    onClick         |  false   | <code>(e: any) => void</code>                             |             |
+|     footer         |  false   | <code>`ReactElement<any>`</code>                          |             |
+|     headerStyles   |  false   | JSON object containing desired CSS for the header part    |             |
+|     contentStyles  |  false   | JSON object containing desired CSS for the content part   |             |
 
 ### default
 

--- a/src/components/sidebar/Sidebar.stories.mdx
+++ b/src/components/sidebar/Sidebar.stories.mdx
@@ -13,17 +13,18 @@ import { PaginationBox } from "../pagination/Pagination.tsx";
 
 ## Sidebar properties
 
-| properties  | required | type                                                                             | description |
-| ---------:  | :------: | :------------------------------------------------------------------------------- | :---------- |
-|   children  |  false   | <code>`ReactElement<any>`</code>                                                 |             |
-|      title  |  false   | string                                                                           |             |
-|    caption  |  false   | string                                                                           |             |
-|     isOpen  |  false   | boolean                                                                          |             |
-|       side  |  false   | <code>onLeft</code>, <code>onRight</code>                                        |             |
-|      width  |  false   | number, string                                                                   |             |
-|    onClick  |  false   | <code>(e: any) => void</code>                                                    |             |
-|     footer  |  false   | <code>`ReactElement<any>`</code>                                                 |             |
-|     padding |  false   | <code>`{top?: string, right?: string, bottom?: string, left?: string}`</code>    |             |
+| properties         | required | type                                                                                                            | description |
+| ----------------:  | :------: | :-------------------------------------------------------------------------------------------------------------- | :---------- |
+|   children         |  false   | <code>`ReactElement<any>`</code>                                                                                |             |
+|      title         |  false   | string                                                                                                          |             |
+|    caption         |  false   | string                                                                                                          |             |
+|     isOpen         |  false   | boolean                                                                                                         |             |
+|       side         |  false   | <code>onLeft</code>, <code>onRight</code>                                                                       |             |
+|      width         |  false   | number, string                                                                                                  |             |
+|    onClick         |  false   | <code>(e: any) => void</code>                                                                                   |             |
+|     footer         |  false   | <code>`ReactElement<any>`</code>                                                                                |             |
+|     headerProps    |  false   | <code>`{reverse?: boolean, padding?: {top?: string, right?: string, bottom?: string, left?: string}}`</code>    |             |
+|     containerProps |  false   | <code>`{padding?: {top?: string, right?: string, bottom?: string, left?: string}}`</code>                       |             |
 
 ### default
 

--- a/src/components/sidebar/Sidebar.stories.mdx
+++ b/src/components/sidebar/Sidebar.stories.mdx
@@ -13,16 +13,17 @@ import { PaginationBox } from "../pagination/Pagination.tsx";
 
 ## Sidebar properties
 
-| properties | required | type                                      | description |
-| ---------: | :------: | :---------------------------------------- | :---------- |
-|   children |  false   | <code>`ReactElement<any>`</code>          |             |
-|      title |  false   | string                                    |             |
-|    caption |  false   | string                                    |             |
-|     isOpen |  false   | boolean                                   |             |
-|       side |  false   | <code>onLeft</code>, <code>onRight</code> |             |
-|      width |  false   | number, string                            |             |
-|    onClick |  false   | <code>(e: any) => void</code>             |             |
-|     footer |  false   | <code>`ReactElement<any>`</code>          |             |
+| properties  | required | type                                                                             | description |
+| ---------:  | :------: | :------------------------------------------------------------------------------- | :---------- |
+|   children  |  false   | <code>`ReactElement<any>`</code>                                                 |             |
+|      title  |  false   | string                                                                           |             |
+|    caption  |  false   | string                                                                           |             |
+|     isOpen  |  false   | boolean                                                                          |             |
+|       side  |  false   | <code>onLeft</code>, <code>onRight</code>                                        |             |
+|      width  |  false   | number, string                                                                   |             |
+|    onClick  |  false   | <code>(e: any) => void</code>                                                    |             |
+|     footer  |  false   | <code>`ReactElement<any>`</code>                                                 |             |
+|     padding |  false   | <code>`{top?: string, right?: string, bottom?: string, left?: string}`</code>    |             |
 
 ### default
 

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -35,8 +35,8 @@ export function Sidebar({
   side,
   isOpen,
   footer,
-  headerProps,
-  containerProps,
+  headerStyles,
+  contentStyles,
   onClick = () => undefined,
   ...props
 }: SidebarProps) {
@@ -63,7 +63,7 @@ export function Sidebar({
         <Inner isOpen={isOpen} {...props}>
           {isOpen && (
             <>
-              <Header {...headerProps} reverse={side === "onLeft"}>
+              <Header reverse={side === "onLeft"} style={headerStyles}>
                 <header>
                   <Title
                     tag="span"
@@ -82,7 +82,7 @@ export function Sidebar({
                   type="button"
                 />
               </Header>
-              <Container {...containerProps}>
+              <Container style={contentStyles}>
                 <Content tag="div">{children}</Content>
               </Container>
               {footer && <FooterSidebar>{footer}</FooterSidebar>}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -35,6 +35,7 @@ export function Sidebar({
   side,
   isOpen,
   footer,
+  padding,
   onClick = () => undefined,
   ...props
 }: SidebarProps) {
@@ -61,7 +62,7 @@ export function Sidebar({
         <Inner isOpen={isOpen} {...props}>
           {isOpen && (
             <>
-              <Header reverse={side === "onLeft"}>
+              <Header reverse={side === "onLeft"} padding={padding}>
                 <header>
                   <Title
                     tag="span"
@@ -80,7 +81,7 @@ export function Sidebar({
                   type="button"
                 />
               </Header>
-              <Container>
+              <Container padding={padding}>
                 <Content tag="div">{children}</Content>
               </Container>
               {footer && <FooterSidebar>{footer}</FooterSidebar>}

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -35,7 +35,8 @@ export function Sidebar({
   side,
   isOpen,
   footer,
-  padding,
+  headerProps,
+  containerProps,
   onClick = () => undefined,
   ...props
 }: SidebarProps) {
@@ -62,7 +63,7 @@ export function Sidebar({
         <Inner isOpen={isOpen} {...props}>
           {isOpen && (
             <>
-              <Header reverse={side === "onLeft"} padding={padding}>
+              <Header {...headerProps} reverse={side === "onLeft"}>
                 <header>
                   <Title
                     tag="span"
@@ -81,7 +82,7 @@ export function Sidebar({
                   type="button"
                 />
               </Header>
-              <Container padding={padding}>
+              <Container {...containerProps}>
                 <Content tag="div">{children}</Content>
               </Container>
               {footer && <FooterSidebar>{footer}</FooterSidebar>}

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -24,15 +24,11 @@ export const Header = styled.div<HeaderProps>`
   border-bottom: 1px solid ${theme.color.border.border01};
   background-color: ${theme.color.background.ui01};
   line-height: ${theme.lineHeight};
+  padding: ${theme.spacing.spacing04};
   margin: 0 auto;
   box-sizing: border-box;
   justify-content: ${({ reverse }) => (reverse ? "flex-end" : "space-between")};
   flex-direction: ${({ reverse }) => (reverse ? "row-reverse" : "row")};
-
-  padding-top: ${theme.spacing.spacing04};
-  padding-right: ${theme.spacing.spacing04};
-  padding-bottom: ${theme.spacing.spacing04};
-  padding-left: ${theme.spacing.spacing04};
 `;
 
 export const Title = styled(Text)`
@@ -129,8 +125,7 @@ export const Inner = styled.div<InnerProps>`
 `;
 
 export const Container = styled.div`
-  padding-right: ${theme.spacing.spacing04};
-  padding-left: ${theme.spacing.spacing04};
+  padding: 0 ${theme.spacing.spacing04};
   flex: 1;
 `;
 

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -9,6 +9,7 @@ import {
   CloseLayerProps,
   InnerProps,
   HeaderProps,
+  ContainerProps,
 } from "./types";
 
 export const Header = styled.div<HeaderProps>`
@@ -24,11 +25,17 @@ export const Header = styled.div<HeaderProps>`
   border-bottom: 1px solid ${theme.color.border.border01};
   background-color: ${theme.color.background.ui01};
   line-height: ${theme.lineHeight};
-  padding: ${theme.spacing.spacing04};
   margin: 0 auto;
   box-sizing: border-box;
   justify-content: ${({ reverse }) => (reverse ? "flex-end" : "space-between")};
   flex-direction: ${({ reverse }) => (reverse ? "row-reverse" : "row")};
+  padding-top: ${({ padding }) =>
+    padding?.top ? padding.top : theme.spacing.spacing04};
+  padding-right: ${({ padding }) =>
+    padding?.right ? padding.right : theme.spacing.spacing04};
+  padding-bottom: ${theme.spacing.spacing04};
+  padding-left: ${({ padding }) =>
+    padding?.left ? padding.left : theme.spacing.spacing04};
 `;
 
 export const Title = styled(Text)`
@@ -124,8 +131,13 @@ export const Inner = styled.div<InnerProps>`
   z-index: 2;
 `;
 
-export const Container = styled.div`
-  padding: 0 ${theme.spacing.spacing04};
+export const Container = styled.div<ContainerProps>`
+  padding-right: ${({ padding }) =>
+    padding?.right ? padding.right : theme.spacing.spacing04};
+  padding-left: ${({ padding }) =>
+    padding?.left ? padding.left : theme.spacing.spacing04};
+  padding-bottom: ${({ padding }) =>
+    padding?.bottom ? padding.bottom : theme.spacing.spacing04};
   flex: 1;
 `;
 

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -33,7 +33,8 @@ export const Header = styled.div<HeaderProps>`
     padding?.top ? padding.top : theme.spacing.spacing04};
   padding-right: ${({ padding }) =>
     padding?.right ? padding.right : theme.spacing.spacing04};
-  padding-bottom: ${theme.spacing.spacing04};
+  padding-bottom: ${({ padding }) =>
+    padding?.bottom ? padding.bottom : theme.spacing.spacing04};
   padding-left: ${({ padding }) =>
     padding?.left ? padding.left : theme.spacing.spacing04};
 `;
@@ -132,12 +133,14 @@ export const Inner = styled.div<InnerProps>`
 `;
 
 export const Container = styled.div<ContainerProps>`
+  padding-top: ${({ padding }) =>
+    padding?.top ? padding.top : theme.spacing.spacing04};
   padding-right: ${({ padding }) =>
     padding?.right ? padding.right : theme.spacing.spacing04};
-  padding-left: ${({ padding }) =>
-    padding?.left ? padding.left : theme.spacing.spacing04};
   padding-bottom: ${({ padding }) =>
     padding?.bottom ? padding.bottom : theme.spacing.spacing04};
+  padding-left: ${({ padding }) =>
+    padding?.left ? padding.left : theme.spacing.spacing04};
   flex: 1;
 `;
 

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -9,7 +9,6 @@ import {
   CloseLayerProps,
   InnerProps,
   HeaderProps,
-  ContainerProps,
 } from "./types";
 
 export const Header = styled.div<HeaderProps>`
@@ -29,14 +28,11 @@ export const Header = styled.div<HeaderProps>`
   box-sizing: border-box;
   justify-content: ${({ reverse }) => (reverse ? "flex-end" : "space-between")};
   flex-direction: ${({ reverse }) => (reverse ? "row-reverse" : "row")};
-  padding-top: ${({ padding }) =>
-    padding?.top ? padding.top : theme.spacing.spacing04};
-  padding-right: ${({ padding }) =>
-    padding?.right ? padding.right : theme.spacing.spacing04};
-  padding-bottom: ${({ padding }) =>
-    padding?.bottom ? padding.bottom : theme.spacing.spacing04};
-  padding-left: ${({ padding }) =>
-    padding?.left ? padding.left : theme.spacing.spacing04};
+
+  padding-top: ${theme.spacing.spacing04};
+  padding-right: ${theme.spacing.spacing04};
+  padding-bottom: ${theme.spacing.spacing04};
+  padding-left: ${theme.spacing.spacing04};
 `;
 
 export const Title = styled(Text)`
@@ -132,15 +128,9 @@ export const Inner = styled.div<InnerProps>`
   z-index: 2;
 `;
 
-export const Container = styled.div<ContainerProps>`
-  padding-top: ${({ padding }) =>
-    padding?.top ? padding.top : theme.spacing.spacing04};
-  padding-right: ${({ padding }) =>
-    padding?.right ? padding.right : theme.spacing.spacing04};
-  padding-bottom: ${({ padding }) =>
-    padding?.bottom ? padding.bottom : theme.spacing.spacing04};
-  padding-left: ${({ padding }) =>
-    padding?.left ? padding.left : theme.spacing.spacing04};
+export const Container = styled.div`
+  padding-right: ${theme.spacing.spacing04};
+  padding-left: ${theme.spacing.spacing04};
   flex: 1;
 `;
 

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -18,7 +18,8 @@ export type SidebarProps = {
   reverse?: boolean;
   onClick?: () => void;
   footer?: React.ReactNode;
-  padding?: PaddingProps;
+  headerProps?: HeaderProps;
+  containerProps?: ContainerProps;
 };
 
 export type BackgroundProps = {

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -1,13 +1,6 @@
 import { ButtonProps } from "../button";
 import { SVGIconProps } from "../svgicon";
 
-export type PaddingProps = {
-  top?: string;
-  right?: string;
-  bottom?: string;
-  left?: string;
-};
-
 export type SidebarProps = {
   children?: React.ReactNode;
   title?: string;

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -18,8 +18,8 @@ export type SidebarProps = {
   reverse?: boolean;
   onClick?: () => void;
   footer?: React.ReactNode;
-  headerProps?: HeaderProps;
-  containerProps?: ContainerProps;
+  headerStyles?: React.CSSProperties;
+  contentStyles?: React.CSSProperties;
 };
 
 export type BackgroundProps = {
@@ -44,9 +44,4 @@ export type SidebarButtonProps = {
 
 export type HeaderProps = {
   reverse?: boolean;
-  padding?: PaddingProps;
-};
-
-export type ContainerProps = {
-  padding?: PaddingProps;
 };

--- a/src/components/sidebar/types.ts
+++ b/src/components/sidebar/types.ts
@@ -1,6 +1,13 @@
 import { ButtonProps } from "../button";
 import { SVGIconProps } from "../svgicon";
 
+export type PaddingProps = {
+  top?: string;
+  right?: string;
+  bottom?: string;
+  left?: string;
+};
+
 export type SidebarProps = {
   children?: React.ReactNode;
   title?: string;
@@ -11,15 +18,19 @@ export type SidebarProps = {
   reverse?: boolean;
   onClick?: () => void;
   footer?: React.ReactNode;
+  padding?: PaddingProps;
 };
+
 export type BackgroundProps = {
   isOpen?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
+
 export type CloseLayerProps = {
   isOpen?: boolean;
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
+
 export type InnerProps = {
   width?: number | string;
   side?: "onLeft" | "onRight";
@@ -32,4 +43,9 @@ export type SidebarButtonProps = {
 
 export type HeaderProps = {
   reverse?: boolean;
+  padding?: PaddingProps;
+};
+
+export type ContainerProps = {
+  padding?: PaddingProps;
 };


### PR DESCRIPTION
# What

- What was done in this Pull Request
Sidebars contents can now be padded via optional padding parameter
- How was it before
- Screenshots
- Any other information that may be useful for the dev to review Pull Request

## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
Exaggerated example:
<img width="489" alt="image" src="https://user-images.githubusercontent.com/5813564/183662419-88016616-5665-4647-943d-c2954e298bb8.png">
<img width="528" alt="image" src="https://user-images.githubusercontent.com/5813564/183663523-290b7c4b-9faf-4326-8739-690c6534bd44.png">
