### PR TITLE
[KLAR-7483] Increased z-index of sidebar footer part so it doesnt get obstructed …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "typescript": "^4.2.2"
       },
       "engines": {
-        "node": ">=18.12.0",
+        "node": "^16.18.0 || ^18.12.0",
         "npm": ">=8.19.2"
       },
       "peerDependencies": {

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -136,7 +136,7 @@ export const SidebarCloseButton = styled(Button)`
 
 export const FooterSidebar = styled.div`
   position: sticky;
-  z-index: ${theme.zindex.default};
+  z-index: 2;
   bottom: 0;
   right: 0;
   left: 0;

--- a/src/components/sidebar/styles.tsx
+++ b/src/components/sidebar/styles.tsx
@@ -136,7 +136,7 @@ export const SidebarCloseButton = styled(Button)`
 
 export const FooterSidebar = styled.div`
   position: sticky;
-  z-index: 2;
+  z-index: ${theme.zindex.sticky};
   bottom: 0;
   right: 0;
   left: 0;


### PR DESCRIPTION
…by sidebar content

https://nordcloud.atlassian.net/browse/KLAR-7483

# What

- What was done in this Pull Request
Footer got obstructed by content that had z-index set to at least 2. Im remedying this by increasing sidebar footer wrappers z-index to 2.
- How was it before
- Screenshots
- Any other information that may be useful for the dev to review Pull Request

## Testing

- [x] Is this change covered by the unit tests?

- [x] Is this change covered by the integration tests?

- [x] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before
<img width="557" alt="image" src="https://user-images.githubusercontent.com/5813564/200288411-66eb9ee6-0f08-4e94-89b7-29f0e4f0f835.png">

### After
<img width="566" alt="image" src="https://user-images.githubusercontent.com/5813564/200288485-df4e7577-f670-489b-b5a3-0321655ecaaa.png">
