### PR TITLE
Disable reviewdog for draft prs

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   reviewdog:
+    if: github.event.pull_request.draft == false
     name: Reviewdog
     runs-on: ubuntu-latest
     permissions:
@@ -32,7 +33,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          filter_mode: file
+          filter_mode: added
           level: warning
           fail_on_error: false
           eslint_flags: '--ignore-path .gitignore .'


### PR DESCRIPTION
# What

- Disabled reviewdog for draft PRs to avoid comment spam while developing
- Show ESLint comments only for changes instead of entire files

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
