### PR TITLE
`Select` `i-index` fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "7.1.1",
+      "version": "7.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/select/Select.tsx
+++ b/src/components/select/Select.tsx
@@ -64,6 +64,7 @@ const SelectContainer = styled.div`
     }
     &__menu {
       box-shadow: ${theme.shadow.shadow04};
+      z-index: ${theme.zindex.dropdown};
     }
     &__option {
       &--is-selected {


### PR DESCRIPTION
# What

- we've got information that it may happen that `Select` can overlap with components that have slightly higher stacking order (`<Tab>` that is below `<Select>` in HTML structure for example) so we have adjusted the `z-index` of `Select` to be significantly bigger

## Compatibility

- [x] Does this change maintain backward compatibility?
