### PR TITLE
changed mouseenter/mouseleave to pointerenter/pointerleave

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "7.8.2",
+      "version": "7.8.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "7.8.2",
+  "version": "7.8.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/extendedTooltip/ExtendedTooltip.tsx
+++ b/src/components/extendedTooltip/ExtendedTooltip.tsx
@@ -18,7 +18,7 @@ type Timeout = {
   hideTimeout?: number;
 };
 
-type Status = "danger" | "warning" | "success" | "notification";
+type Status = "danger" | "notification" | "success" | "warning";
 
 export type ExtendedTooltipProps = Timeout & {
   caption: React.ReactNode;
@@ -86,8 +86,8 @@ export function ExtendedTooltip({
   return (
     <TooltipWrapper
       ref={wrapperRef}
-      onMouseEnter={() => updateIsHovered(true, showTimeout)}
-      onMouseLeave={() => updateIsHovered(false, hideTimeout)}
+      onPointerEnter={() => updateIsHovered(true, showTimeout)}
+      onPointerLeave={() => updateIsHovered(false, hideTimeout)}
     >
       <Tooltip
         isHovered={isHovered}


### PR DESCRIPTION
# What

- changed handling from mouse events to pointer events so to address [issue](https://github.com/facebook/react/issues/18753#issuecomment-629375920)

## Compatibility

- [x] Does this change maintain backward compatibility?
