### PR TITLE
Setting up `max-width` to modal

### DIFF
--- a/src/components/modal/Modal.stories.mdx
+++ b/src/components/modal/Modal.stories.mdx
@@ -118,3 +118,32 @@ import { Button } from "../button";
     }}
   </Story>
 </Canvas>
+
+### Modal Confirm with long text and scroll
+
+<Canvas>
+  <Story name="confirm modal long body text">
+    {() => {
+      const { isOpen, open, close } = useDisclosure();
+      const action = () => alert("Confirmed");
+      return (
+        <>
+          <Button onClick={open}>Open modal</Button>
+          <ModalConfirm
+            contentLabel="Account"
+            isOpen={isOpen}
+            confirm={action}
+            onClose={close}
+            actionLabel="Confirm"
+          >
+            Do you really want to delete account{" "}
+            <em>
+              1033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e141033195400904dd389a6788ef9de5e14
+            </em>
+            ?
+          </ModalConfirm>
+        </>
+      );
+    }}
+  </Story>
+</Canvas>

--- a/src/components/modal/styles.ts
+++ b/src/components/modal/styles.ts
@@ -31,7 +31,8 @@ const showTranslateY = keyframes`
 
 export const ModalBox = styled(Box)<ModalBoxProps>`
   min-width: ${({ modalMinWidth }) => modalMinWidth || "32rem"};
-  overflow: hidden;
+  max-width: 95vw;
+  overflow: scroll;
   font-family: ${theme.fonts.body};
   line-height: ${theme.lineHeight};
   opacity: 0;

--- a/src/components/modal/styles.ts
+++ b/src/components/modal/styles.ts
@@ -32,7 +32,7 @@ const showTranslateY = keyframes`
 export const ModalBox = styled(Box)<ModalBoxProps>`
   min-width: ${({ modalMinWidth }) => modalMinWidth || "32rem"};
   max-width: 95vw;
-  overflow: scroll;
+  overflow: auto;
   font-family: ${theme.fonts.body};
   line-height: ${theme.lineHeight};
   opacity: 0;


### PR DESCRIPTION
# What

- added `max-width` and `overflow:scroll` to modal to avoid modal window box to be bigger than screen size and prevent user from having access to any button

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/2817128/221814908-46572ed4-0a72-4c56-8e0a-d0a29557c02c.png)

### After
#### Before scroll
![image](https://user-images.githubusercontent.com/2817128/221814952-9df28d6d-38d6-4805-8127-79ecd9f596a0.png)

#### After scroll
![image](https://user-images.githubusercontent.com/2817128/221815039-2ffa9448-dfee-4886-abda-99dcafe43937.png)
