### PR TITLE
Allow react 18 as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "8.14.0",
+      "version": "8.15.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,9 +73,9 @@
         "npm": "~8.19.0"
       },
       "peerDependencies": {
-        "react": "^16.13.0 || ^17.0.0",
-        "react-dom": "^16.13.0 || ^17.0.0",
-        "styled-components": "^5.3.0"
+        "react": ">=16.13.0",
+        "react-dom": ">=16.13.0",
+        "styled-components": ">=5.3.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     ]
   },
   "peerDependencies": {
-    "react": "^16.13.0 || ^17.0.0",
-    "react-dom": "^16.13.0 || ^17.0.0",
-    "styled-components": "^5.3.0"
+    "react": ">=16.13.0",
+    "react-dom": ">=16.13.0",
+    "styled-components": ">=5.3.0"
   },
   "dependencies": {
     "@types/styled-system": "^5.1.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What

- Allow React 18 and styled-components v6 as peer dependencies

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
