### PR TITLE
Add knip and lockfile-lint to renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -105,7 +105,9 @@
         "prettier",
         "cross-env",
         "npm-run-all",
-        "patch-package"
+        "patch-package",
+        "lockfile-lint",
+        "knip"
       ],
       "automerge": true
     },


### PR DESCRIPTION
# What

- Added `knip` and `lockfile-lint` to Renovate config so they will be automatically updated

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
