### PR TITLE
Extend lockfile-lint config

### DIFF
--- a/lockfile-lint.config.js
+++ b/lockfile-lint.config.js
@@ -1,0 +1,14 @@
+/** @see https://github.com/lirantal/lockfile-lint/tree/main/packages/lockfile-lint#file-based-configuration */
+module.exports = {
+  type: "npm",
+  path: "package-lock.json",
+  allowedHosts: "npm",
+  validateHttps: true,
+  validateIntegrity: false,
+  validatePackageNames: true,
+  allowedPackageNameAliases: [
+    "string-width-cjs:string-width",
+    "strip-ansi-cjs: strip-ansi",
+    "wrap-ansi-cjs:wrap-ansi",
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:quiet": "npm run lint -- --quiet",
     "lint:css": "stylelint '**/*.+(ts|tsx)'",
     "lint:css:quiet": "npm run lint:css -- --quiet",
-    "lint:lockfile": "lockfile-lint --type npm --path package-lock.json --allowed-hosts npm --validate-https",
+    "lint:lockfile": "lockfile-lint",
     "validate:all": "npm-run-all --parallel check:types check:format check:knip lint:quiet lint:css:quiet lint:lockfile test:all",
     "postinstall": "patch-package",
     "prepare": "husky install"


### PR DESCRIPTION
# What

- Moved lockfile-lint config to separate file, added validation for package names

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
