### PR TITLE
Add stability days for renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,10 @@
   "rebaseWhen": "conflicted",
   "reviewers": ["@nordcloud/core-frontend-reviewers"],
   "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
     /********** Add labels **********/
     {
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
# What

- Added a new option that should protect us from broken npm packages

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
