### PR TITLE
Deprecate and remove awesome styled grid from main bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,18 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "9.2.0",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "9.2.0",
-      "hasInstallScript": true,
+      "version": "10.0.0",
       "license": "MIT",
       "dependencies": {
         "@types/styled-system": "^5.1.20",
         "date-fns": "^2.30.0",
         "lodash.clonedeep": "^4.5.0",
         "polished": "^4.2.2",
-        "react-awesome-styled-grid": "^3.1.4",
         "react-content-loader": "^6.2.1",
         "react-day-picker": "^8.8.2",
         "react-helmet": "^6.1.0",
@@ -55,6 +53,7 @@
         "patch-package": "^6.5.1",
         "prettier": "^3.0.3",
         "react": "^18.2.0",
+        "react-awesome-styled-grid": "^3.1.4",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.2.0",
         "rollup": "^3.29.4",
@@ -205,6 +204,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
       "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -2144,6 +2144,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
       "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dev": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -2205,7 +2206,8 @@
     "node_modules/@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "dev": true
     },
     "node_modules/@emotion/unitless": {
       "version": "0.8.1",
@@ -9765,6 +9767,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.1.tgz",
       "integrity": "sha512-XaZ1IRvJRWucLh+6g9XCtX7fvfscUjSQ0xsznp7o9hhoog12up5c3+6BTTLE10Zg8xu/nGJNtiFwT13wwuwdsQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -9778,7 +9781,8 @@
     "node_modules/babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
@@ -10472,6 +10476,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11148,6 +11153,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11156,6 +11162,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
       "dependencies": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -19583,7 +19590,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -22990,7 +22998,8 @@
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "node_modules/postcss/node_modules/source-map": {
       "version": "0.6.1",
@@ -23392,6 +23401,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-awesome-styled-grid/-/react-awesome-styled-grid-3.1.4.tgz",
       "integrity": "sha512-cV3px+UleWW6z4mosSMKbSqE6i/vpnG1U2N8zWJdqEZAFmhq2XYItZ7sTBivmuit6qfKyozkZv+blkuMDiEmlw==",
+      "dev": true,
       "peerDependencies": {
         "prop-types": ">=15.6.0",
         "react": ">=16.8.0",
@@ -24606,7 +24616,8 @@
     "node_modules/shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "node_modules/shebang-command": {
       "version": "1.2.0",
@@ -25215,6 +25226,7 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -25248,7 +25260,8 @@
     "node_modules/styled-components/node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+      "dev": true
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -27672,6 +27685,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
       "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.22.5"
       }
@@ -29029,6 +29043,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
       "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dev": true,
       "requires": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -29080,7 +29095,8 @@
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "dev": true
     },
     "@emotion/unitless": {
       "version": "0.8.1",
@@ -34517,6 +34533,7 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.1.tgz",
       "integrity": "sha512-XaZ1IRvJRWucLh+6g9XCtX7fvfscUjSQ0xsznp7o9hhoog12up5c3+6BTTLE10Zg8xu/nGJNtiFwT13wwuwdsQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -34527,7 +34544,8 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
+      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==",
+      "dev": true
     },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",
@@ -35031,7 +35049,8 @@
     "camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true
     },
     "caniuse-lite": {
       "version": "1.0.30001549",
@@ -35535,12 +35554,14 @@
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true
     },
     "css-to-react-native": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
       "requires": {
         "camelize": "^1.0.0",
         "css-color-keywords": "^1.0.0",
@@ -41810,7 +41831,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -44224,7 +44246,8 @@
     "postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -44514,6 +44537,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/react-awesome-styled-grid/-/react-awesome-styled-grid-3.1.4.tgz",
       "integrity": "sha512-cV3px+UleWW6z4mosSMKbSqE6i/vpnG1U2N8zWJdqEZAFmhq2XYItZ7sTBivmuit6qfKyozkZv+blkuMDiEmlw==",
+      "dev": true,
       "requires": {}
     },
     "react-colorful": {
@@ -45425,7 +45449,8 @@
     "shallowequal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -45915,6 +45940,7 @@
       "version": "5.3.11",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -45931,7 +45957,8 @@
         "@emotion/unitless": {
           "version": "0.7.5",
           "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+          "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "9.2.0",
+  "version": "10.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -35,8 +35,7 @@
     "lint:css:quiet": "npm run lint:css -- --quiet",
     "lint:lockfile": "lockfile-lint",
     "validate:all": "npm-run-all --parallel check:types check:format check:knip lint:quiet lint:css:quiet lint:lockfile test:all",
-    "postinstall": "patch-package",
-    "prepare": "husky install"
+    "prepare": "patch-package && husky install"
   },
   "engines": {
     "node": "~18.12.0 || ~18.13.0",
@@ -64,7 +63,6 @@
     "date-fns": "^2.30.0",
     "lodash.clonedeep": "^4.5.0",
     "polished": "^4.2.2",
-    "react-awesome-styled-grid": "^3.1.4",
     "react-content-loader": "^6.2.1",
     "react-day-picker": "^8.8.2",
     "react-helmet": "^6.1.0",
@@ -105,6 +103,7 @@
     "patch-package": "^6.5.1",
     "prettier": "^3.0.3",
     "react": "^18.2.0",
+    "react-awesome-styled-grid": "^3.1.4",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.2.0",
     "rollup": "^3.29.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,3 @@
-export {
-  Container,
-  Row,
-  Col,
-  Hidden,
-  Visible,
-} from "react-awesome-styled-grid";
 export { DayPicker } from "react-day-picker";
 
 export * from "./components";

--- a/src/stories/Grid.mdx
+++ b/src/stories/Grid.mdx
@@ -3,6 +3,43 @@ import * as GridStories from "./Grid.stories";
 
 <Meta of={GridStories} />
 
+## Note
+
+Below guide is deprecated, the grid library mentioned here is no longer maintained and has a bug that requires additional setup.
+
+### Setup
+
+#### Install grid library
+
+```bash
+npm install react-awesome-styled-grid
+```
+
+#### Implement required fix
+
+```bash
+npm install -D patch-package
+```
+
+Make necessary changes inside two files:
+
+`/node_modules/react-awesome-styled-grid/lib/react-awesome-styled-grid.cjs.js`
+`/node_modules/react-awesome-styled-grid/lib/react-awesome-styled-grid.es.js`
+
+```text
+-  void 0 === i && (i = global);
++  void 0 === i && (i = window);
+```
+
+Update `package.json`:
+
+```text
+"scripts": {
+ ...
+ "postinstall": "patch-package"
+}
+```
+
 ## Basic usage
 
 <Canvas>

--- a/src/stories/Grid.mdx
+++ b/src/stories/Grid.mdx
@@ -31,6 +31,12 @@ Make necessary changes inside two files:
 +  void 0 === i && (i = window);
 ```
 
+Apply patch:
+
+```text
+npx patch-package react-awesome-styled-grid
+```
+
 Update `package.json`:
 
 ```text


### PR DESCRIPTION
# What

This is a breaking change that addresses #676 

- Awesome Styled Grid Library is no longer appended to the main bundle and was removed from dependencies
- Added deprecation note inside `Grid` story

## Compatibility

- [ ] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
