### PR TITLE
Ignore renovate updates for babel styled components plugin

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -151,5 +151,9 @@
       "depTypeList": ["peerDependencies"],
       "enabled": false
     }
+  ],
+  "ignoreDeps": [
+    // Breaks compilation with bigger versions
+    "babel-plugin-styled-components"
   ]
 }


### PR DESCRIPTION
# What

- Disable renovate updates for `babel-styled-components-plugin` due to it breaking with new versions

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
