### PR TITLE
fix(Release): Remove npm audit signatures command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_KEY }}
       - run: npm ci
-      - run: npm audit signatures
       - run: npm run build
       - run: cat .npmrc
       - run: npm publish --access public

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -17,7 +17,6 @@ jobs:
           node-version-file: package.json
 
       - run: npm ci
-      - run: npm audit signatures
 
       - name: Prettier
         uses: EPMatt/reviewdog-action-prettier@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
           node-version-file: package.json
 
       - run: npm ci
-      - run: npm audit signatures
       - run: cat .npmrc
       - run: npm run validate:all
       - run: npm run build

--- a/amplify.yml
+++ b/amplify.yml
@@ -5,7 +5,6 @@ frontend:
       commands:
         - nvm use
         - npm ci
-        - npm audit signatures
     build:
       commands:
         - npm run build-storybook

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nordcloud/gnui",
-  "version": "10.4.0",
+  "version": "10.4.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nordcloud/gnui",
-      "version": "10.4.0",
+      "version": "10.4.6",
       "license": "MIT",
       "dependencies": {
         "@types/styled-system": "^5.1.22",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "10.4.5",
+  "version": "10.4.6",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What

- There was an issue with releasing of a new version of GNUI. The cause is the **npm audit signatures** command, and the NPM team has not solved the problem.
- Failing pipeline example: https://github.com/nordcloud/GNUI/actions/runs/13191006122/job/36823832542
<img width="1111" alt="Screenshot 2025-02-07 at 13 36 15" src="https://github.com/user-attachments/assets/abb78296-b7c6-4dda-80e6-f6e7983f0f55" />

## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [x] Does this change maintain backward compatibility?

## Screenshots

### Before
N/A
### After
N/A