### PR TITLE
[AP-6115] Change table header font weight from 700 to 500

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "11.4.1",
+  "version": "11.5.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/components/table/Table.tsx
+++ b/src/components/table/Table.tsx
@@ -87,6 +87,7 @@ const Tr = styled.tr``;
 
 const Th = styled.th<{ width?: string }>`
   border-bottom: 2px solid ${theme.color.border.border01};
+  font-weight: ${theme.fontWeights.medium};
 `;
 
 function Table(props: React.ComponentProps<typeof StyledTable>) {


### PR DESCRIPTION
# What

Change Table.th font-weight from 700 to 500

 ## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [ ] Does this change maintain backward compatibility?

## Screenshots

### Before
<img width="1369" height="674" alt="Screenshot 2026-04-02 at 11 03 40" src="https://github.com/user-attachments/assets/b338e42d-2604-49f1-bc5d-5fe9191368e2" />


### After
<img width="1364" height="660" alt="Screenshot 2026-04-02 at 11 03 09" src="https://github.com/user-attachments/assets/6f1f8fdb-186e-44f3-99f2-2940e46f192c" />
