### PR TITLE
fix: use Node 24, NPM 11 for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version-file: package.json
+          node-version: "24"
+      - run: npm install -g npm@11
       - run: echo "registry=https://registry.npmjs.org/" > .npmrc
       - run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         env:
@@ -18,4 +19,4 @@ jobs:
       - run: npm audit signatures
       - run: npm run build
       - run: cat .npmrc
-      - run: npm publish --access public
+      - run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "24"
-      - run: npm install -g npm@11
       - run: echo "registry=https://registry.npmjs.org/" > .npmrc
       - run: echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nordcloud/gnui",
   "description": "Nordcloud Design System - a collection of reusable React components used in Nordcloud's SaaS products",
-  "version": "11.5.1",
+  "version": "11.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# What

- use Node 24, NPM 11 for npm publish

## Testing

- [ ] Is this change covered by the unit tests?

- [ ] Is this change covered by the integration tests?

- [ ] Is this change covered by the automated acceptance tests? (if applicable)

## Compatibility

- [ ] Does this change maintain backward compatibility?

## Screenshots

### Before

### After
